### PR TITLE
Potential fix for code scanning alert no. 2: Use of password hash with insufficient computational effort

### DIFF
--- a/src/lib/crypto-link.ts
+++ b/src/lib/crypto-link.ts
@@ -7,12 +7,14 @@ import crypto from "crypto";
  * @returns {string} - Chaîne chiffrée sous la forme iv:encrypted
  */
 export function encrypt(text: string, password: string): string {
-    const key = crypto.createHash("sha256").update(password).digest();
-    const iv = crypto.randomBytes(16);
+    const salt = crypto.randomBytes(16); // 16 bytes salt
+    const iv = crypto.randomBytes(16); // 16 bytes IV
+    const key = crypto.pbkdf2Sync(password, salt, 100_000, 32, "sha256"); // 100,000 iterations, 32 bytes key
     const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
     let encrypted = cipher.update(text, "utf8", "base64");
     encrypted += cipher.final("base64");
-    return iv.toString("base64") + ":" + encrypted;
+    // Output: salt_base64:iv_base64:encrypted
+    return salt.toString("base64") + ":" + iv.toString("base64") + ":" + encrypted;
 }
 
 /**
@@ -22,8 +24,10 @@ export function encrypt(text: string, password: string): string {
  * @returns {string} - Texte déchiffré
  */
 export function decrypt(encrypted: string, password: string): string {
-    const [ivBase64, encryptedText] = encrypted.split(":");
-    const key = crypto.createHash("sha256").update(password).digest();
+    const [saltBase64, ivBase64, encryptedText] = encrypted.split(":");
+    if (!saltBase64 || !ivBase64 || !encryptedText) throw new Error("Invalid encrypted format");
+    const salt = Buffer.from(saltBase64, "base64");
+    const key = crypto.pbkdf2Sync(password, salt, 100_000, 32, "sha256");
     const iv = Buffer.from(ivBase64, "base64");
     const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
     let decrypted = decipher.update(encryptedText, "base64", "utf8");


### PR DESCRIPTION
Potential fix for [https://github.com/TuroYT/snowshare/security/code-scanning/2](https://github.com/TuroYT/snowshare/security/code-scanning/2)

To fix this problem, the derivation of the AES key from the user-provided password in both the `encrypt` and `decrypt` functions should use a password-based key derivation function (KDF) such as PBKDF2. This KDF will require the use of a salt and a sufficiently high iteration count to slow down brute-force attacks. A salt should be randomly generated and stored along with the ciphertext (typically as an additional header or field), and during decryption, the salt should be parsed from the input and used with the password to regenerate the AES key. 

Specifically, the following changes are required in `src/lib/crypto-link.ts`:
- Replace usage of `crypto.createHash("sha256")` with `crypto.pbkdf2Sync` in both `encrypt` and `decrypt`.
- During encryption, generate a random salt (e.g., 16 bytes), derive the key using PBKDF2 with the password and salt, and concatenate the salt and IV with the encrypted value for storage (format: `salt:iv:encrypted`).
- During decryption, parse the salt, IV, and encrypted data from the input, derive the key using PBKDF2 with the salt and password, and proceed with decryption.
- Add any required imports and constants (iteration count, etc).

No other files need to be modified, based on provided context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
