### PR TITLE
Potential fix for code scanning alert no. 336: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TuroYT/snowshare/security/code-scanning/336](https://github.com/TuroYT/snowshare/security/code-scanning/336)

To fix the problem, you should add a `permissions` block at the appropriate scope within `.github/workflows/ci.yml`. Since there is only one job and none of the steps require more than read access to repository contents, the block should specify `permissions: contents: read`. You can place this block at the job level (`build-and-test:`) or, for broader applicability, at the root level of the workflow (so it defaults for all jobs unless overridden). Here, root-level placement is preferred for maintainability and clarity. No additional imports or dependencies are needed; just add the following under the workflow's `name:` and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
