### PR TITLE
Potential fix for code scanning alert no. 338: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build and lint project


### PR DESCRIPTION
Potential fix for [https://github.com/TuroYT/snowshare/security/code-scanning/338](https://github.com/TuroYT/snowshare/security/code-scanning/338)

To fix this, explicitly declare a minimal `permissions` block so the `GITHUB_TOKEN` used by this workflow has only the scopes it needs. This workflow checks out code (needs `contents: read`) and posts comments on pull requests (needs `pull-requests: write`; `issues: write` is often not required for PRs, but adding it is harmless and sometimes necessary depending on repo settings). The safest and clearest fix is to add a `permissions` block at the workflow root (applies to all jobs) directly under the `on:` section, specifying least‑privilege permissions.

Concretely, in `.github/workflows/build-self-hosted.yml`, add a new `permissions:` mapping between the `on:` block (lines 3–7) and the `jobs:` block (line 9). Set `contents: read` and `pull-requests: write`. No imports or extra methods are needed; this is purely a YAML configuration change. Existing functionality (build, lint, docker build, and PR commenting) will continue to work with these permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
