### PR TITLE
fix: add slug existence check to link and paste share creation

### DIFF
--- a/src/app/api/shares/(linkShare)/linkshare.ts
+++ b/src/app/api/shares/(linkShare)/linkshare.ts
@@ -15,6 +15,14 @@ export const createLinkShare = async (
     slug?: string,
     password?: string
 ) => {
+    // Check if slug already exists
+    if (slug) {
+        const existingShare = await prisma.share.findUnique({ where: { slug } });
+        if (existingShare) {
+            return { error: "This custom URL is already taken. Please choose another one." };
+        }
+    }
+    
     // Validate original URL format and protocol
     const urlValidation = validateUrl(urlOriginal);
     if (!urlValidation.valid) {

--- a/src/app/api/shares/(pasteShare)/pasteshareshare.ts
+++ b/src/app/api/shares/(pasteShare)/pasteshareshare.ts
@@ -35,6 +35,14 @@ export const createPasteShare = async (
     return { error: "Invalid slug. It must contain between 3 and 30 alphanumeric characters, dashes or underscores." };
   }
 
+  // Check if slug already exists
+  if (slug) {
+    const existingShare = await prisma.share.findUnique({ where: { slug } });
+    if (existingShare) {
+      return { error: "This custom URL is already taken. Please choose another one." };
+    }
+  }
+
   // Validate expiration date if provided
   if (expiresAt && new Date(expiresAt) <= new Date()) {
     return { error: "Expiration date must be in the future." };

--- a/src/app/api/shares/route.ts
+++ b/src/app/api/shares/route.ts
@@ -28,7 +28,8 @@ async function POST(req: NextRequest) {
                 const { urlOriginal, expiresAt, slug, password } = data;
                 const result = await createLinkShare(urlOriginal, req, expiresAt, slug, password);
                 if (result?.error) {
-                    return NextResponse.json({ error: result.error }, { status: 400 });
+                    const statusCode = result.status || 400;
+                    return NextResponse.json({ error: result.error }, { status: statusCode });
                 }
                 return NextResponse.json({ share: result }, { status: 201 });
             }
@@ -38,7 +39,8 @@ async function POST(req: NextRequest) {
                 const expiresAtDate = expiresAt ? new Date(expiresAt) : undefined;
                 const result = await createPasteShare(paste, pastelanguage, req, expiresAtDate, slug, password);
                 if (result?.error) {
-                    return NextResponse.json({ error: result.error }, { status: 400 });
+                    const statusCode = result.status || 400;
+                    return NextResponse.json({ error: result.error }, { status: statusCode });
                 }
                 return NextResponse.json({ share: result }, { status: 201 });
             }


### PR DESCRIPTION
## Description

Add a check to ensure that the custom slug does not already exist when creating link and paste shares. This prevents users from using an already taken slug.

## Type of Change

- [x] 🐛 **Bug fix** (non-breaking change which fixes an issue)

## Related Issues

- Fixes #

## Checklist

### Code Quality
- [ ] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards)
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my code
- [ ] My code is properly typed (TypeScript)

### Testing
- [ ] I have tested my changes locally
- [ ] I have added tests for new functionality (if applicable)
- [ ] All existing tests pass
- [ ] My changes do not break existing functionality

### Documentation
- [ ] I have updated documentation if necessary
- [ ] I have added comments to complex code sections
- [ ] I have updated the README if needed

### Security & Best Practices
- [ ] My changes do not introduce security vulnerabilities
- [ ] I have not exposed sensitive data or credentials
- [ ] I have followed database migration best practices (if applicable)

## Screenshots (if applicable)

## Additional Notes

## PR Title Format

Please ensure your PR title follows the conventional commit format:
- `feat: add new feature`
- `fix: resolve specific bug` 
- `docs: update documentation`
- `refactor: improve code structure`
- `test: add missing tests`
- `chore: update dependencies`

