### PR TITLE
feat: SSO auto-link at user creation (closes #195)

### DIFF
--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,0 +1,36 @@
+# Copilot Code Review Instructions
+
+## Tone & approach
+
+- Be concise. Flag real issues, skip nitpicks.
+- Do not request changes for style preferences that are already consistent with the rest of the codebase.
+- Do not suggest adding comments, docstrings, or type annotations to unchanged code.
+- Do not suggest refactoring code that is not part of the PR diff.
+- If something looks intentional and works, don't flag it.
+
+## What to flag
+
+- Security issues: injection, XSS, credential leaks, missing auth checks
+- Bugs: logic errors, off-by-one, race conditions, unhandled error paths
+- Breaking changes: Prisma migrations that could lose data, API contract changes without backwards compat
+- Missing i18n: new user-facing text not added to all 6 locale files (`en`, `fr`, `de`, `es`, `nl`, `pl`)
+- Import violations: relative imports (`../`) instead of `@/` alias
+
+## What NOT to flag
+
+- Missing JSDoc or inline comments on clear code
+- Suggesting `const` over `let` when `let` is valid
+- Proposing abstractions for code used in only one place
+- Renaming variables to longer names when the short name is clear in context
+- Adding error handling for impossible states (e.g., validating internal function args)
+- Cosmetic formatting differences already handled by Prettier/ESLint
+
+## Project-specific rules
+
+- **Passwords** must use bcryptjs with cost 12
+- **Slugs** must match `/^[a-zA-Z0-9_-]{3,30}$/`
+- **API responses**: success `{ data }` or `{ share }`, error `{ error: "message" }` with proper HTTP status
+- **Prisma imports**: types from `@/generated/prisma`, client from `@/lib/prisma`
+- **Client components**: must have `"use client"` directive
+- **Translations**: use `t("section.key")` client-side, `getT(request)` server-side
+- **API errors**: use `apiError(request, ErrorCode.XXX)` from `@/lib/api-errors`, not hardcoded responses

--- a/prisma/migrations/20260406153308_add_sso_auto_link/migration.sql
+++ b/prisma/migrations/20260406153308_add_sso_auto_link/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "ssoAutoLink" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE INDEX "Share_ipSource_idx" ON "Share"("ipSource");
+
+-- CreateIndex
+CREATE INDEX "Share_ownerId_idx" ON "Share"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "Share_expiresAt_idx" ON "Share"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "Share_createdAt_idx" ON "Share"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
   isAdmin       Boolean   @default(false)
+  ssoAutoLink   Boolean   @default(false)
   accounts      Account[]
   sessions      Session[]
   shares        Share[]
@@ -115,17 +116,17 @@ model Settings {
   authMaxUpload Int     @default(51200) // ~50Go
   anoIpQuota    Int     @default(4096) // 4Go
   authIpQuota   Int     @default(102400) // ~100Go
-  
+
   // Unit format preferences (MiB/GiB vs MB/GB)
   useGiBForAnon Boolean @default(false) // Use GiB (true) or MiB (false) for anonymous users
   useGiBForAuth Boolean @default(false) // Use GiB (true) or MiB (false) for authenticated users
-  
+
   // Branding - Identity
   appName       String  @default("SnowShare")
   appDescription String @default("Share your files, pastes, and URLs securely")
   logoUrl       String?
   faviconUrl    String?
-  
+
   // Branding - Colors (Theme System)
   primaryColor      String  @default("#3B82F6")  // Primary color (buttons, links)
   primaryHover      String  @default("#2563EB")  // Primary color hover state

--- a/src/__tests__/api/admin-users.test.ts
+++ b/src/__tests__/api/admin-users.test.ts
@@ -90,9 +90,14 @@ describe("POST /api/admin/users", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rejects string 'true' for ssoAutoLink — requires password", async () => {
-    // Non-boolean truthy values must not bypass the password requirement
+  it("rejects string 'true' for ssoAutoLink with 400", async () => {
+    // Non-boolean values must be explicitly rejected
     const res = await POST(makeRequest({ email: "user@test.com", ssoAutoLink: "true" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects numeric 1 for ssoAutoLink with 400", async () => {
+    const res = await POST(makeRequest({ email: "user@test.com", ssoAutoLink: 1 }));
     expect(res.status).toBe(400);
   });
 

--- a/src/__tests__/api/admin-users.test.ts
+++ b/src/__tests__/api/admin-users.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("next-auth", () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/lib/security", () => ({
+  hashPassword: jest.fn((p: string) => Promise.resolve(`hashed:${p}`)),
+}));
+
+jest.mock("@/lib/i18n-server", () => ({
+  detectLocale: jest.fn(() => "en"),
+  translate: jest.fn((_locale: string, key: string) => key),
+}));
+
+import { POST } from "@/app/api/admin/users/route";
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { NextRequest } from "next/server";
+
+const adminSession = { user: { id: "admin-id" } };
+
+function makeRequest(body: object) {
+  return new NextRequest("http://localhost/api/admin/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/admin/users", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getServerSession as jest.Mock).mockResolvedValue(adminSession);
+    (prisma.user.findUnique as jest.Mock).mockImplementation(
+      ({ where }: { where: { id?: string; email?: string } }) => {
+        if (where.id === "admin-id") return Promise.resolve({ id: "admin-id", isAdmin: true });
+        return Promise.resolve(null);
+      }
+    );
+    (prisma.user.create as jest.Mock).mockResolvedValue({
+      id: "new-id",
+      email: "user@test.com",
+      name: null,
+      isAdmin: false,
+      createdAt: new Date(),
+      _count: { shares: 0 },
+    });
+  });
+
+  it("creates user with password (default flow)", async () => {
+    const res = await POST(makeRequest({ email: "user@test.com", password: "password123" }));
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.user.email).toBe("user@test.com");
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ password: "hashed:password123", ssoAutoLink: false }),
+      })
+    );
+  });
+
+  it("creates SSO-only user without password when ssoAutoLink is true", async () => {
+    const res = await POST(makeRequest({ email: "sso@test.com", ssoAutoLink: true }));
+    expect(res.status).toBe(201);
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ password: undefined, ssoAutoLink: true }),
+      })
+    );
+  });
+
+  it("returns 400 when password missing and ssoAutoLink is false", async () => {
+    const res = await POST(makeRequest({ email: "user@test.com" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/api/admin-users.test.ts
+++ b/src/__tests__/api/admin-users.test.ts
@@ -89,4 +89,15 @@ describe("POST /api/admin/users", () => {
     const res = await POST(makeRequest({ email: "user@test.com" }));
     expect(res.status).toBe(400);
   });
+
+  it("rejects string 'true' for ssoAutoLink — requires password", async () => {
+    // Non-boolean truthy values must not bypass the password requirement
+    const res = await POST(makeRequest({ email: "user@test.com", ssoAutoLink: "true" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects weak password even when ssoAutoLink is true", async () => {
+    const res = await POST(makeRequest({ email: "sso@test.com", ssoAutoLink: true, password: "abc" }));
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/__tests__/lib/auth-sso-autolink.test.ts
+++ b/src/__tests__/lib/auth-sso-autolink.test.ts
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    settings: { findFirst: jest.fn() },
+    user: { findUnique: jest.fn(), update: jest.fn() },
+    account: { create: jest.fn() },
+    verificationToken: { findFirst: jest.fn(), delete: jest.fn() },
+    oAuthProvider: { findMany: jest.fn() },
+  },
+}));
+
+jest.mock("@/lib/providers", () => ({
+  providerMap: {},
+}));
+
+import { prisma } from "@/lib/prisma";
+import { getAuthOptions } from "@/lib/auth";
+
+const mockUser = { email: "user@example.com", id: "u1", name: "Test" };
+const mockAccount = {
+  provider: "azure-ad",
+  type: "oauth",
+  providerAccountId: "aad-123",
+  refresh_token: null,
+  access_token: "tok",
+  expires_at: null,
+  token_type: "Bearer",
+  scope: "openid",
+  id_token: null,
+  session_state: null,
+};
+
+describe("signIn callback - SSO auto-link", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({ allowSignin: true });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.account.create as jest.Mock).mockResolvedValue({});
+    (prisma.user.update as jest.Mock).mockResolvedValue({});
+    (prisma.verificationToken.findFirst as jest.Mock).mockResolvedValue(null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (prisma.oAuthProvider as any).findMany.mockResolvedValue([]);
+  });
+
+  it("auto-links account when ssoAutoLink is true", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1",
+      email: "user@example.com",
+      ssoAutoLink: true,
+      accounts: [],
+    });
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    const result = await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.account.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: "u1", provider: "azure-ad" }),
+      })
+    );
+  });
+
+  it("resets ssoAutoLink to false after auto-linking", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1",
+      email: "user@example.com",
+      ssoAutoLink: true,
+      accounts: [],
+    });
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { ssoAutoLink: false },
+    });
+  });
+
+  it("blocks SSO login when user exists, no ssoAutoLink, and no link token", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1",
+      email: "user@example.com",
+      ssoAutoLink: false,
+      accounts: [],
+    });
+    (prisma.verificationToken.findFirst as jest.Mock).mockResolvedValue(null);
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    const result = await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("allows SSO login when account already linked regardless of ssoAutoLink", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "u1",
+      email: "user@example.com",
+      ssoAutoLink: false,
+      accounts: [{ provider: "azure-ad" }],
+    });
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    const result = await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(result).toBe(true);
+    expect(prisma.account.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/auth-sso-autolink.test.ts
+++ b/src/__tests__/lib/auth-sso-autolink.test.ts
@@ -2,14 +2,19 @@
  * @jest-environment node
  */
 
+const mockPrisma = {
+  settings: { findFirst: jest.fn() },
+  user: { findUnique: jest.fn(), update: jest.fn() },
+  account: { create: jest.fn() },
+  verificationToken: { findFirst: jest.fn(), delete: jest.fn() },
+  oAuthProvider: { findMany: jest.fn() },
+  $transaction: jest.fn((fn: (tx: typeof mockPrisma) => Promise<unknown>) =>
+    fn(mockPrisma)
+  ),
+};
+
 jest.mock("@/lib/prisma", () => ({
-  prisma: {
-    settings: { findFirst: jest.fn() },
-    user: { findUnique: jest.fn(), update: jest.fn() },
-    account: { create: jest.fn() },
-    verificationToken: { findFirst: jest.fn(), delete: jest.fn() },
-    oAuthProvider: { findMany: jest.fn() },
-  },
+  prisma: mockPrisma,
 }));
 
 jest.mock("@/lib/providers", () => ({
@@ -36,12 +41,17 @@ const mockAccount = {
 describe("signIn callback - SSO auto-link", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({ allowSignin: true });
+    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({
+      allowSignin: true,
+    });
     (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
     (prisma.account.create as jest.Mock).mockResolvedValue({});
     (prisma.user.update as jest.Mock).mockResolvedValue({});
     (prisma.verificationToken.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.oAuthProvider.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)
+    );
   });
 
   it("auto-links account and resets flag when ssoAutoLink is true", async () => {
@@ -63,6 +73,7 @@ describe("signIn callback - SSO auto-link", () => {
     });
 
     expect(result).toBe(true);
+    expect(prisma.$transaction).toHaveBeenCalled();
     expect(prisma.account.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ userId: "u1", provider: "azure-ad" }),
@@ -75,7 +86,9 @@ describe("signIn callback - SSO auto-link", () => {
   });
 
   it("blocks ssoAutoLink user when allowSignin is false", async () => {
-    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({ allowSignin: false });
+    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({
+      allowSignin: false,
+    });
     (prisma.user.findUnique as jest.Mock).mockResolvedValue({
       id: "u1",
       email: "user@example.com",
@@ -139,5 +152,78 @@ describe("signIn callback - SSO auto-link", () => {
 
     expect(result).toBe(true);
     expect(prisma.account.create).not.toHaveBeenCalled();
+  });
+
+  it("handles race condition: P2002 unique constraint, account already linked — allows sign-in and resets flag", async () => {
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: "u1",
+        email: "user@example.com",
+        ssoAutoLink: true,
+        accounts: [],
+      })
+      .mockResolvedValueOnce({
+        id: "u1",
+        email: "user@example.com",
+        ssoAutoLink: true,
+        accounts: [
+          { provider: "azure-ad", providerAccountId: "aad-123" },
+        ],
+      });
+
+    const p2002Error = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+    });
+    (prisma.$transaction as jest.Mock).mockRejectedValue(p2002Error);
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    const result = await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(result).toBe(true);
+    // Flag should be reset since concurrent request left it true
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { ssoAutoLink: false },
+    });
+  });
+
+  it("handles race condition: P2002 unique constraint, account not linked — returns false", async () => {
+    (prisma.user.findUnique as jest.Mock)
+      .mockResolvedValueOnce({
+        id: "u1",
+        email: "user@example.com",
+        ssoAutoLink: true,
+        accounts: [],
+      })
+      .mockResolvedValueOnce({
+        id: "u1",
+        email: "user@example.com",
+        ssoAutoLink: true,
+        accounts: [], // account still not linked (different provider)
+      });
+
+    const p2002Error = Object.assign(new Error("Unique constraint failed"), {
+      code: "P2002",
+    });
+    (prisma.$transaction as jest.Mock).mockRejectedValue(p2002Error);
+
+    const options = await getAuthOptions();
+    const signIn = options.callbacks!.signIn!;
+    const result = await signIn({
+      user: mockUser,
+      account: mockAccount,
+      profile: undefined,
+      email: undefined,
+      credentials: undefined,
+    });
+
+    expect(result).toBe(false);
   });
 });

--- a/src/__tests__/lib/auth-sso-autolink.test.ts
+++ b/src/__tests__/lib/auth-sso-autolink.test.ts
@@ -5,7 +5,7 @@
 const mockPrisma = {
   settings: { findFirst: jest.fn() },
   user: { findUnique: jest.fn(), update: jest.fn() },
-  account: { create: jest.fn() },
+  account: { create: jest.fn(), findFirst: jest.fn() },
   verificationToken: { findFirst: jest.fn(), delete: jest.fn() },
   oAuthProvider: { findMany: jest.fn() },
   $transaction: jest.fn((fn: (tx: typeof mockPrisma) => Promise<unknown>) =>
@@ -46,12 +46,10 @@ describe("signIn callback - SSO auto-link", () => {
     });
     (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
     (prisma.account.create as jest.Mock).mockResolvedValue({});
+    (prisma.account.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.user.update as jest.Mock).mockResolvedValue({});
     (prisma.verificationToken.findFirst as jest.Mock).mockResolvedValue(null);
     (prisma.oAuthProvider.findMany as jest.Mock).mockResolvedValue([]);
-    (prisma.$transaction as jest.Mock).mockImplementation(
-      (fn: (tx: typeof mockPrisma) => Promise<unknown>) => fn(mockPrisma)
-    );
   });
 
   it("auto-links account and resets flag when ssoAutoLink is true", async () => {
@@ -157,19 +155,21 @@ describe("signIn callback - SSO auto-link", () => {
   it("handles race condition: P2002 unique constraint, account already linked — allows sign-in and resets flag", async () => {
     (prisma.user.findUnique as jest.Mock)
       .mockResolvedValueOnce({
+        // Initial lookup: user has ssoAutoLink=true, no linked account yet
         id: "u1",
         email: "user@example.com",
         ssoAutoLink: true,
         accounts: [],
       })
       .mockResolvedValueOnce({
-        id: "u1",
-        email: "user@example.com",
+        // Re-check after P2002: flag still set (concurrent request hasn't reset it)
         ssoAutoLink: true,
-        accounts: [
-          { provider: "azure-ad", providerAccountId: "aad-123" },
-        ],
       });
+    // Concurrent request already created the account link
+    (prisma.account.findFirst as jest.Mock).mockResolvedValue({
+      provider: "azure-ad",
+      providerAccountId: "aad-123",
+    });
 
     const p2002Error = Object.assign(new Error("Unique constraint failed"), {
       code: "P2002",
@@ -195,19 +195,14 @@ describe("signIn callback - SSO auto-link", () => {
   });
 
   it("handles race condition: P2002 unique constraint, account not linked — returns false", async () => {
-    (prisma.user.findUnique as jest.Mock)
-      .mockResolvedValueOnce({
-        id: "u1",
-        email: "user@example.com",
-        ssoAutoLink: true,
-        accounts: [],
-      })
-      .mockResolvedValueOnce({
-        id: "u1",
-        email: "user@example.com",
-        ssoAutoLink: true,
-        accounts: [], // account still not linked (different provider)
-      });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "u1",
+      email: "user@example.com",
+      ssoAutoLink: true,
+      accounts: [],
+    });
+    // No matching linked account found after P2002
+    (prisma.account.findFirst as jest.Mock).mockResolvedValue(null);
 
     const p2002Error = Object.assign(new Error("Unique constraint failed"), {
       code: "P2002",

--- a/src/__tests__/lib/auth-sso-autolink.test.ts
+++ b/src/__tests__/lib/auth-sso-autolink.test.ts
@@ -45,7 +45,17 @@ describe("signIn callback - SSO auto-link", () => {
     (prisma.oAuthProvider as any).findMany.mockResolvedValue([]);
   });
 
-  it("auto-links account when ssoAutoLink is true", async () => {
+  it("auto-links account and resets flag when ssoAutoLink is true", async () => {
+    const callOrder: string[] = [];
+    (prisma.account.create as jest.Mock).mockImplementation(() => {
+      callOrder.push("account.create");
+      return Promise.resolve({});
+    });
+    (prisma.user.update as jest.Mock).mockImplementation(() => {
+      callOrder.push("user.update");
+      return Promise.resolve({});
+    });
+
     (prisma.user.findUnique as jest.Mock).mockResolvedValue({
       id: "u1",
       email: "user@example.com",
@@ -69,9 +79,15 @@ describe("signIn callback - SSO auto-link", () => {
         data: expect.objectContaining({ userId: "u1", provider: "azure-ad" }),
       })
     );
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: { ssoAutoLink: false },
+    });
+    expect(callOrder).toEqual(["account.create", "user.update"]);
   });
 
-  it("resets ssoAutoLink to false after auto-linking", async () => {
+  it("blocks ssoAutoLink user when allowSignin is false", async () => {
+    (prisma.settings.findFirst as jest.Mock).mockResolvedValue({ allowSignin: false });
     (prisma.user.findUnique as jest.Mock).mockResolvedValue({
       id: "u1",
       email: "user@example.com",
@@ -81,7 +97,7 @@ describe("signIn callback - SSO auto-link", () => {
 
     const options = await getAuthOptions();
     const signIn = options.callbacks!.signIn!;
-    await signIn({
+    const result = await signIn({
       user: mockUser,
       account: mockAccount,
       profile: undefined,
@@ -89,10 +105,8 @@ describe("signIn callback - SSO auto-link", () => {
       credentials: undefined,
     });
 
-    expect(prisma.user.update).toHaveBeenCalledWith({
-      where: { id: "u1" },
-      data: { ssoAutoLink: false },
-    });
+    expect(result).toBe(false);
+    expect(prisma.account.create).not.toHaveBeenCalled();
   });
 
   it("blocks SSO login when user exists, no ssoAutoLink, and no link token", async () => {

--- a/src/__tests__/lib/auth-sso-autolink.test.ts
+++ b/src/__tests__/lib/auth-sso-autolink.test.ts
@@ -41,21 +41,10 @@ describe("signIn callback - SSO auto-link", () => {
     (prisma.account.create as jest.Mock).mockResolvedValue({});
     (prisma.user.update as jest.Mock).mockResolvedValue({});
     (prisma.verificationToken.findFirst as jest.Mock).mockResolvedValue(null);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (prisma.oAuthProvider as any).findMany.mockResolvedValue([]);
+    (prisma.oAuthProvider.findMany as jest.Mock).mockResolvedValue([]);
   });
 
   it("auto-links account and resets flag when ssoAutoLink is true", async () => {
-    const callOrder: string[] = [];
-    (prisma.account.create as jest.Mock).mockImplementation(() => {
-      callOrder.push("account.create");
-      return Promise.resolve({});
-    });
-    (prisma.user.update as jest.Mock).mockImplementation(() => {
-      callOrder.push("user.update");
-      return Promise.resolve({});
-    });
-
     (prisma.user.findUnique as jest.Mock).mockResolvedValue({
       id: "u1",
       email: "user@example.com",
@@ -83,7 +72,6 @@ describe("signIn callback - SSO auto-link", () => {
       where: { id: "u1" },
       data: { ssoAutoLink: false },
     });
-    expect(callOrder).toEqual(["account.create", "user.update"]);
   });
 
   it("blocks ssoAutoLink user when allowSignin is false", async () => {

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -133,7 +133,10 @@ export async function POST(request: NextRequest) {
       return apiError(request, ErrorCode.INVALID_EMAIL_FORMAT);
     }
 
-    // Strict boolean validation — reject non-boolean truthy values (e.g. "true" as a string)
+    // Explicit boolean validation — reject non-boolean values (e.g. "true" as a string) with a 400
+    if (ssoAutoLink !== undefined && typeof ssoAutoLink !== "boolean") {
+      return apiError(request, ErrorCode.INVALID_REQUEST);
+    }
     const ssoAutoLinkBool = ssoAutoLink === true;
 
     // Password is required unless this is an SSO-only user

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -114,7 +114,6 @@ export async function POST(request: NextRequest) {
     return apiError(request, ErrorCode.UNAUTHORIZED);
   }
 
-  // Check if user is admin
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
   });
@@ -124,9 +123,8 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { email, name, password, isAdmin: makeAdmin } = await request.json();
+    const { email, name, password, isAdmin: makeAdmin, ssoAutoLink } = await request.json();
 
-    // Validate input
     if (!email || typeof email !== "string") {
       return apiError(request, ErrorCode.EMAIL_PASSWORD_REQUIRED);
     }
@@ -135,36 +133,33 @@ export async function POST(request: NextRequest) {
       return apiError(request, ErrorCode.INVALID_EMAIL_FORMAT);
     }
 
-    if (!password || typeof password !== "string") {
-      return apiError(request, ErrorCode.EMAIL_PASSWORD_REQUIRED);
+    // Password is required unless this is an SSO-only user
+    if (!ssoAutoLink) {
+      if (!password || typeof password !== "string") {
+        return apiError(request, ErrorCode.EMAIL_PASSWORD_REQUIRED);
+      }
+      if (!isValidPassword(password)) {
+        return apiError(request, ErrorCode.PASSWORD_LENGTH, {
+          min: PASSWORD_MIN_LENGTH,
+          max: PASSWORD_MAX_LENGTH,
+        });
+      }
     }
 
-    if (!isValidPassword(password)) {
-      return apiError(request, ErrorCode.PASSWORD_LENGTH, {
-        min: PASSWORD_MIN_LENGTH,
-        max: PASSWORD_MAX_LENGTH,
-      });
-    }
-
-    // Check if user already exists
-    const existingUser = await prisma.user.findUnique({
-      where: { email },
-    });
-
+    const existingUser = await prisma.user.findUnique({ where: { email } });
     if (existingUser) {
       return apiError(request, ErrorCode.USER_ALREADY_EXISTS);
     }
 
-    // Hash password
-    const hashedPassword = await hashPassword(password);
+    const hashedPassword = password ? await hashPassword(password) : undefined;
 
-    // Create user
     const newUser = await prisma.user.create({
       data: {
         email,
         name: name || undefined,
         password: hashedPassword,
         isAdmin: makeAdmin || false,
+        ssoAutoLink: ssoAutoLink || false,
       },
       select: {
         id: true,
@@ -172,9 +167,7 @@ export async function POST(request: NextRequest) {
         name: true,
         isAdmin: true,
         createdAt: true,
-        _count: {
-          select: { shares: true },
-        },
+        _count: { select: { shares: true } },
       },
     });
 

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -133,12 +133,19 @@ export async function POST(request: NextRequest) {
       return apiError(request, ErrorCode.INVALID_EMAIL_FORMAT);
     }
 
+    // Strict boolean validation — reject non-boolean truthy values (e.g. "true" as a string)
+    const ssoAutoLinkBool = ssoAutoLink === true;
+
     // Password is required unless this is an SSO-only user
-    if (!ssoAutoLink) {
+    if (!ssoAutoLinkBool) {
       if (!password || typeof password !== "string") {
         return apiError(request, ErrorCode.EMAIL_PASSWORD_REQUIRED);
       }
-      if (!isValidPassword(password)) {
+    }
+
+    // Validate password length whenever a password is provided, even for SSO users
+    if (password !== undefined && password !== null && password !== "") {
+      if (typeof password !== "string" || !isValidPassword(password)) {
         return apiError(request, ErrorCode.PASSWORD_LENGTH, {
           min: PASSWORD_MIN_LENGTH,
           max: PASSWORD_MAX_LENGTH,
@@ -159,7 +166,7 @@ export async function POST(request: NextRequest) {
         name: name || undefined,
         password: hashedPassword,
         isAdmin: makeAdmin || false,
-        ssoAutoLink: ssoAutoLink || false,
+        ssoAutoLink: ssoAutoLinkBool,
       },
       select: {
         id: true,

--- a/src/components/admin/CreateUserDialog.tsx
+++ b/src/components/admin/CreateUserDialog.tsx
@@ -19,6 +19,7 @@ export default function CreateUserDialog({
   const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [isAdmin, setIsAdmin] = useState(false);
+  const [ssoAutoLink, setSsoAutoLink] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,8 +35,9 @@ export default function CreateUserDialog({
         body: JSON.stringify({
           email,
           name: name || undefined,
-          password,
+          password: ssoAutoLink ? undefined : password,
           isAdmin,
+          ssoAutoLink,
         }),
       });
 
@@ -49,6 +51,7 @@ export default function CreateUserDialog({
       setName("");
       setPassword("");
       setIsAdmin(false);
+      setSsoAutoLink(false);
       onUserCreated();
       onClose();
     } catch (err) {
@@ -105,24 +108,49 @@ export default function CreateUserDialog({
             />
           </div>
 
-          {/* Password */}
-          <div>
-            <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
-              {t("admin.users.password")} *
-            </label>
+          {/* SSO Auto-link checkbox */}
+          <div className="flex items-start gap-3 p-3 bg-[var(--surface)]/30 border border-[var(--border)]/30 rounded-lg">
             <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              placeholder={t("admin.users.password_placeholder")}
-              className="w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] placeholder-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
-              required
+              type="checkbox"
+              id="ssoAutoLink"
+              checked={ssoAutoLink}
+              onChange={(e) => setSsoAutoLink(e.target.checked)}
+              className="w-4 h-4 mt-0.5 rounded border-[var(--border)] bg-[var(--surface)]/50 cursor-pointer"
               disabled={loading}
             />
-            <p className="text-xs text-[var(--foreground-muted)] mt-1">
-              {t("admin.users.password_hint")}
-            </p>
+            <div>
+              <label
+                htmlFor="ssoAutoLink"
+                className="text-sm font-medium text-[var(--foreground)] cursor-pointer"
+              >
+                {t("admin.users.sso_auto_link")}
+              </label>
+              <p className="text-xs text-[var(--foreground-muted)] mt-0.5">
+                {t("admin.users.sso_auto_link_hint")}
+              </p>
+            </div>
           </div>
+
+          {/* Password */}
+          {!ssoAutoLink && (
+            <div>
+              <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+                {t("admin.users.password")} *
+              </label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={t("admin.users.password_placeholder")}
+                className="w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] placeholder-[var(--foreground-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                required
+                disabled={loading}
+              />
+              <p className="text-xs text-[var(--foreground-muted)] mt-1">
+                {t("admin.users.password_hint")}
+              </p>
+            </div>
+          )}
 
           {/* Admin checkbox */}
           <div className="flex items-center gap-3">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -424,7 +424,10 @@
       "password_hint": "Mindestens 6 Zeichen",
       "make_admin": "Zum Administrator Ernennen",
       "create": "Benutzer Erstellen",
-      "creating": "Wird erstellt..."
+      "creating": "Wird erstellt...",
+      "sso_auto_link": "Automatische SSO-Verknüpfung",
+      "sso_auto_link_hint": "Wenn aktiviert, wird das Konto beim ersten Login über einen SSO-Anbieter automatisch verknüpft. Kein Passwort erforderlich.",
+      "sso_only": "Nur SSO"
     },
     "settings": {
       "title": "Einstellungen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -428,7 +428,10 @@
       "password_hint": "Minimum 6 characters",
       "make_admin": "Make Administrator",
       "create": "Create User",
-      "creating": "Creating..."
+      "creating": "Creating...",
+      "sso_auto_link": "Allow SSO auto-link",
+      "sso_auto_link_hint": "When enabled, the user's account will be automatically linked the first time they sign in via any SSO provider. No password needed.",
+      "sso_only": "SSO only"
     },
     "settings": {
       "title": "Settings",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -424,7 +424,10 @@
       "password_hint": "Mínimo 6 caracteres",
       "make_admin": "Hacer Administrador",
       "create": "Crear Usuario",
-      "creating": "Creando..."
+      "creating": "Creando...",
+      "sso_auto_link": "Vinculación SSO automática",
+      "sso_auto_link_hint": "Si está activado, la cuenta se vinculará automáticamente la primera vez que el usuario inicie sesión con cualquier proveedor SSO. No se necesita contraseña.",
+      "sso_only": "Solo SSO"
     },
     "settings": {
       "title": "Configuración",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -428,7 +428,10 @@
       "password_hint": "Minimum 6 caractères",
       "make_admin": "Faire un administrateur",
       "create": "Créer l'utilisateur",
-      "creating": "Création..."
+      "creating": "Création...",
+      "sso_auto_link": "Liaison SSO automatique",
+      "sso_auto_link_hint": "Si activé, le compte sera automatiquement lié lors de la première connexion via un fournisseur SSO. Aucun mot de passe requis.",
+      "sso_only": "SSO uniquement"
     },
     "settings": {
       "title": "Paramètres",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -432,7 +432,10 @@
       "password_hint": "Minimaal 6 tekens",
       "make_admin": "Beheerder Maken",
       "create": "Gebruiker Aanmaken",
-      "creating": "Wordt aangemaakt..."
+      "creating": "Wordt aangemaakt...",
+      "sso_auto_link": "Automatisch SSO-koppelen",
+      "sso_auto_link_hint": "Indien ingeschakeld, wordt het account automatisch gekoppeld bij de eerste SSO-aanmelding. Geen wachtwoord vereist.",
+      "sso_only": "Alleen SSO"
     },
     "settings": {
       "title": "Instellingen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -429,7 +429,10 @@
       "password_hint": "Minimum 6 znaków",
       "make_admin": "Nadaj Administratora",
       "create": "Utwórz Użytkownika",
-      "creating": "Tworzenie..."
+      "creating": "Tworzenie...",
+      "sso_auto_link": "Automatyczne łączenie SSO",
+      "sso_auto_link_hint": "Po włączeniu konto zostanie automatycznie powiązane przy pierwszym logowaniu przez dostawcę SSO. Hasło nie jest wymagane.",
+      "sso_only": "Tylko SSO"
     },
     "settings": {
       "title": "Ustawienia",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -133,46 +133,64 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         if (!account) return false;
         if (account.provider === "credentials") return true;
 
-        // For OAuth providers – email is required to identify users
         if (!user.email) {
           return "/auth/signin?error=OAuthNoEmail";
         }
 
         const settings = await prisma.settings.findFirst();
 
-        // Check if user already exists
         const existingUser = await prisma.user.findUnique({
           where: { email: user.email },
           include: { accounts: true },
         });
 
         if (existingUser) {
-          // Verify if the account is already linked
+          // Account already linked — allow sign in
           const accountExists = existingUser.accounts.find(
             (acc) => acc.provider === account.provider
           );
+          if (accountExists) return true;
 
-          if (accountExists) {
-            // Already linked - allow sign in
-            return true;
+          // Admin flagged this user for SSO auto-link
+          if (existingUser.ssoAutoLink) {
+            try {
+              await prisma.account.create({
+                data: {
+                  userId: existingUser.id,
+                  type: account.type,
+                  provider: account.provider,
+                  providerAccountId: account.providerAccountId,
+                  refresh_token: account.refresh_token,
+                  access_token: account.access_token,
+                  expires_at: account.expires_at,
+                  token_type: account.token_type,
+                  scope: account.scope,
+                  id_token: account.id_token,
+                  session_state: account.session_state as string | null,
+                },
+              });
+              await prisma.user.update({
+                where: { id: existingUser.id },
+                data: { ssoAutoLink: false },
+              });
+              console.log(`✅ SSO auto-link: account linked for ${existingUser.email}`);
+              return true;
+            } catch (error) {
+              console.error(`❌ SSO auto-link error:`, error);
+              return false;
+            }
           }
 
-          // Not linked yet → check if this is an explicit linking attempt
-          // Look for a valid link token for this email and provider
+          // Explicit link token flow (existing behaviour)
           const linkTokenIdentifier = `account-link:${existingUser.email}:${account.provider}`;
-
           const linkToken = await prisma.verificationToken.findFirst({
             where: {
               identifier: linkTokenIdentifier,
-              expires: {
-                gt: new Date(),
-              },
+              expires: { gt: new Date() },
             },
           });
 
-          if (!linkToken) {
-            return false;
-          }
+          if (!linkToken) return false;
 
           try {
             await prisma.account.create({
@@ -190,8 +208,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 session_state: account.session_state as string | null,
               },
             });
-
-            // Delete the token (one-time use)
             await prisma.verificationToken.delete({
               where: {
                 identifier_token: {
@@ -200,7 +216,6 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 },
               },
             });
-
             console.log(`✅ Account linked successfully`);
             return true;
           } catch (error) {
@@ -209,9 +224,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           }
         }
 
-        if (settings && !settings.allowSignin) {
-          return false;
-        }
+        if (settings && !settings.allowSignin) return false;
 
         return true;
       },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -151,6 +151,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           );
           if (accountExists) return true;
 
+          // Respect allowSignin setting for new links
+          if (settings && !settings.allowSignin) return false;
+
           // Admin flagged this user for SSO auto-link
           if (existingUser.ssoAutoLink) {
             try {
@@ -173,10 +176,10 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 where: { id: existingUser.id },
                 data: { ssoAutoLink: false },
               });
-              console.log(`✅ SSO auto-link: account linked for ${existingUser.email}`);
+              console.log(`SSO auto-link: account linked for ${existingUser.email}`);
               return true;
             } catch (error) {
-              console.error(`❌ SSO auto-link error:`, error);
+              console.error("SSO auto-link error:", error);
               return false;
             }
           }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -151,7 +151,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           );
           if (accountExists) return true;
 
-          // Respect allowSignin setting for new links
+          // allowSignin applies to all new link attempts, including ssoAutoLink
           if (settings && !settings.allowSignin) return false;
 
           // Admin flagged this user for SSO auto-link
@@ -176,7 +176,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 where: { id: existingUser.id },
                 data: { ssoAutoLink: false },
               });
-              console.log(`SSO auto-link: account linked for ${existingUser.email}`);
+              console.log(`SSO auto-link: account linked for user ${existingUser.id}`);
               return true;
             } catch (error) {
               console.error("SSO auto-link error:", error);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -188,18 +188,20 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
                 "code" in error &&
                 (error as { code: string }).code === "P2002"
               ) {
-                const refreshedUser = await prisma.user.findUnique({
-                  where: { id: existingUser.id },
-                  include: { accounts: true },
+                const alreadyLinked = await prisma.account.findFirst({
+                  where: {
+                    userId: existingUser.id,
+                    provider: account.provider,
+                    providerAccountId: account.providerAccountId,
+                  },
                 });
-                const alreadyLinked = refreshedUser?.accounts.some(
-                  (acc) =>
-                    acc.provider === account.provider &&
-                    acc.providerAccountId === account.providerAccountId
-                );
                 if (alreadyLinked) {
                   // Reset flag if it wasn't reset yet by the concurrent request
-                  if (refreshedUser?.ssoAutoLink) {
+                  const stillFlagged = await prisma.user.findUnique({
+                    where: { id: existingUser.id },
+                    select: { ssoAutoLink: true },
+                  });
+                  if (stillFlagged?.ssoAutoLink) {
                     await prisma.user.update({
                       where: { id: existingUser.id },
                       data: { ssoAutoLink: false },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -157,28 +157,57 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           // Admin flagged this user for SSO auto-link
           if (existingUser.ssoAutoLink) {
             try {
-              await prisma.account.create({
-                data: {
-                  userId: existingUser.id,
-                  type: account.type,
-                  provider: account.provider,
-                  providerAccountId: account.providerAccountId,
-                  refresh_token: account.refresh_token,
-                  access_token: account.access_token,
-                  expires_at: account.expires_at,
-                  token_type: account.token_type,
-                  scope: account.scope,
-                  id_token: account.id_token,
-                  session_state: account.session_state as string | null,
-                },
-              });
-              await prisma.user.update({
-                where: { id: existingUser.id },
-                data: { ssoAutoLink: false },
+              await prisma.$transaction(async (tx) => {
+                await tx.account.create({
+                  data: {
+                    userId: existingUser.id,
+                    type: account.type,
+                    provider: account.provider,
+                    providerAccountId: account.providerAccountId,
+                    refresh_token: account.refresh_token,
+                    access_token: account.access_token,
+                    expires_at: account.expires_at,
+                    token_type: account.token_type,
+                    scope: account.scope,
+                    id_token: account.id_token,
+                    session_state: account.session_state as string | null,
+                  },
+                });
+                await tx.user.update({
+                  where: { id: existingUser.id },
+                  data: { ssoAutoLink: false },
+                });
               });
               console.log(`SSO auto-link: account linked for user ${existingUser.id}`);
               return true;
             } catch (error) {
+              // Handle unique constraint violation — account may already be linked by a concurrent request
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "code" in error &&
+                (error as { code: string }).code === "P2002"
+              ) {
+                const refreshedUser = await prisma.user.findUnique({
+                  where: { id: existingUser.id },
+                  include: { accounts: true },
+                });
+                const alreadyLinked = refreshedUser?.accounts.some(
+                  (acc) =>
+                    acc.provider === account.provider &&
+                    acc.providerAccountId === account.providerAccountId
+                );
+                if (alreadyLinked) {
+                  // Reset flag if it wasn't reset yet by the concurrent request
+                  if (refreshedUser?.ssoAutoLink) {
+                    await prisma.user.update({
+                      where: { id: existingUser.id },
+                      data: { ssoAutoLink: false },
+                    });
+                  }
+                  return true;
+                }
+              }
               console.error("SSO auto-link error:", error);
               return false;
             }


### PR DESCRIPTION
## Summary

- Adds `ssoAutoLink` flag to `User` model (non-destructive migration, defaults to `false`)
- When an admin creates a user with **Allow SSO auto-link** enabled, the account is automatically linked the first time the user signs in via any configured SSO provider
- Password is optional for SSO-only users
- Auto-link is one-time: the flag resets to `false` after the first successful SSO login

## Changes

- `prisma/schema.prisma` — new `ssoAutoLink` field on `User`
- `src/lib/auth.ts` — auto-link logic in `signIn` callback
- `src/app/api/admin/users/route.ts` — accepts `ssoAutoLink`, password optional when set
- `src/components/admin/CreateUserDialog.tsx` — new checkbox, password hidden for SSO-only users
- `src/i18n/locales/*.json` — keys added in all 6 locales

Closes #195