### PR TITLE
chore: add Docker Hub publishing workflow

### DIFF
--- a/.github/workflows/publish-docker-hub.yml
+++ b/.github/workflows/publish-docker-hub.yml
@@ -1,0 +1,51 @@
+name: Publish Docker Image to Docker Hub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    name: Build & Push to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (multi-platform)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/snowshare
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DATABASE_URL=postgresql://placeholder:placeholder@localhost:5432/snowshare
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -87,18 +87,105 @@
 
 ## Docker
 
-You can run the app and a PostgreSQL database locally using Docker Compose.
+### Quick start (Docker Hub)
 
-1. Copy `.env.example` to `.env` and adjust values as needed.
-2. Build and start the stack:
+The easiest way to run SnowShare — no build needed, PostgreSQL included.
+
+#### Option A — docker-compose (recommended)
+
+1. Create a `docker-compose.yml`:
+
+```yaml
+version: "3.9"
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: snowshare
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    image: turodev/snowshare:latest
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:postgres@db:5432/snowshare
+      NEXTAUTH_URL: http://localhost:3000        # Change to your public URL
+      NEXTAUTH_SECRET: changeme-replace-with-random-secret  # Change this!
+      ALLOW_SIGNUP: "true"
+    ports:
+      - "3000:3000"
+    volumes:
+      - uploads:/app/uploads
+
+volumes:
+  db-data:
+  uploads:
+```
+
+2. Start the stack:
+
+```bash
+docker compose up -d
+```
+
+#### Option B — docker run
+
+Start PostgreSQL first:
+
+```bash
+docker run -d \
+  --name snowshare-db \
+  --network snowshare-net \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=snowshare \
+  -v snowshare-db:/var/lib/postgresql/data \
+  postgres:16-alpine
+```
+
+Then start SnowShare:
+
+```bash
+docker network create snowshare-net
+
+docker run -d \
+  --name snowshare \
+  --network snowshare-net \
+  -p 3000:3000 \
+  -e DATABASE_URL="postgres://postgres:postgres@snowshare-db:5432/snowshare" \
+  -e NEXTAUTH_URL="http://localhost:3000" \
+  -e NEXTAUTH_SECRET="$(openssl rand -base64 32)" \
+  -e ALLOW_SIGNUP="true" \
+  -v snowshare-uploads:/app/uploads \
+  turodev/snowshare:latest
+```
+
+---
+
+The app will be available at http://localhost:3000.
+
+> **Note:** Change `NEXTAUTH_URL` to your public domain and use a strong `NEXTAUTH_SECRET` (generate one with `openssl rand -base64 32`).
+
+Available tags: `latest`, `1.3.9`, `1.3`
+
+### Build from source
 
 ```bash
 docker compose up -d --build
 ```
-
-The app will be available at http://localhost:3000 and PostgreSQL at port 5432. Data persists in the `db-data` volume and uploaded files in the local `uploads/` folder.
-
-On startup, the app runs `prisma migrate deploy` to ensure the database schema is up to date.
 
 4. Initialize the database
 


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions workflow to automatically build and publish Docker images to Docker Hub when a release is published. The workflow:

- Triggers on GitHub release publication events
- Sets up QEMU and Docker Buildx for multi-platform builds (amd64 and arm64)
- Authenticates with Docker Hub using stored secrets
- Generates semantic versioning tags and a latest tag
- Builds and pushes images with GitHub Actions caching for improved build performance

## Type of Change

- [x] 🏗️ **Chore** (maintenance tasks, dependencies, etc.)

## Related Issues

<!-- Link related issues if applicable -->

## Checklist

### Code Quality

- [x] My code follows the [coding standards](../CONTRIBUTING.md#coding-standards)
- [x] I have performed a self-review of my code

### Security & Best Practices

- [x] My changes do not introduce security vulnerabilities
- [x] I have not exposed sensitive data or credentials (using GitHub secrets for credentials)

## Additional Notes

The workflow uses GitHub secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) which need to be configured in the repository settings before this workflow can function. The build includes a placeholder DATABASE_URL build argument as required by the Dockerfile.

https://claude.ai/code/session_01NMpvJzREyqXVHgxpvckj7a