### PR TITLE
ci: fix Docker Hub publish to use package.json version

### DIFF
--- a/.github/workflows/publish-docker-hub.yml
+++ b/.github/workflows/publish-docker-hub.yml
@@ -1,19 +1,32 @@
 name: Publish Docker Image to Docker Hub
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Update Version on Release"]
+    types: [completed]
 
 jobs:
   build-and-push:
     name: Build & Push to Docker Hub
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Get version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "major_minor=$MAJOR.$MINOR" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU (multi-platform)
         uses: docker/setup-qemu-action@v3
@@ -33,8 +46,8 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/snowshare
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=${{ steps.version.outputs.major_minor }}
             type=raw,value=latest
 
       - name: Build and push


### PR DESCRIPTION
## Summary

- Change workflow trigger from `release: published` to `workflow_run` completion of "Update Version on Release"
- Extract version tags directly from `package.json` instead of relying on semver patterns from release event
- Ensures Docker image is built with the correct version after package.json has been updated