### PR TITLE
chore: trigger Docker publish on release event instead of workflow

### DIFF
--- a/.github/workflows/publish-docker-hub.yml
+++ b/.github/workflows/publish-docker-hub.yml
@@ -1,15 +1,13 @@
 name: Publish Docker Image to Docker Hub
 
 on:
-  workflow_run:
-    workflows: ["Update Version on Release"]
-    types: [completed]
+  release:
+    types: [published]
 
 jobs:
   build-and-push:
     name: Build & Push to Docker Hub
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
 
@@ -17,16 +15,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.release.target_commitish }}
 
-      - name: Get version from package.json
+      - name: Compute version from release tag
         id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           MINOR=$(echo "$VERSION" | cut -d. -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "major_minor=$MAJOR.$MINOR" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Bump package.json locally so /api/version reports the release
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Set up QEMU (multi-platform)
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## Description

This PR refactors the Docker Hub publishing workflow to trigger on GitHub release events instead of depending on a separate "Update Version on Release" workflow. The changes improve the workflow's reliability and simplify the CI/CD pipeline.

### Key Changes:
- **Trigger mechanism**: Changed from `workflow_run` (triggered by another workflow) to `release` event (triggered directly on publish)
- **Version source**: Now extracts version from the release tag instead of reading from `package.json`
- **Checkout reference**: Uses the release's target commit instead of hardcoding `main` branch
- **Package.json sync**: Added a step to bump `package.json` locally so the `/api/version` endpoint reports the correct release version

## Type of Change

- [x] 🔧 **Refactor** (workflow improvement and simplification)
- [x] 🏗️ **Chore** (CI/CD maintenance)

## Related Issues

<!-- Link related issues if applicable -->

## Checklist

### Code Quality
- [x] Changes follow workflow best practices
- [x] Self-reviewed for correctness

### Testing
- [x] Workflow syntax is valid
- [x] CI will validate on next release event

### Security & Best Practices
- [x] No security vulnerabilities introduced
- [x] No sensitive data exposed
- [x] Workflow permissions remain minimal

## Additional Notes

This change eliminates the dependency on an external workflow trigger, making the Docker publish process more direct and reliable. The version is now sourced from the release tag (with optional `v` prefix stripped), ensuring consistency between the release and the published Docker image.

https://claude.ai/code/session_01Jiva9S8uzSoDcomqMGC53e