### PR TITLE
ci(semgrep): fix timeout by fetching full history and adding timeouts

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: semgrep ci --timeout 120 --timeout-threshold 3
+      - run: semgrep ci --timeout 60 --timeout-threshold 3 --max-memory 5000 --oss-only
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-          SEMGREP_TIMEOUT: "300"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -14,10 +14,14 @@ jobs:
     name: Semgrep Scan
     runs-on: [self-hosted]
     if: github.event.pull_request.draft == false
+    timeout-minutes: 20
     container:
       image: returntocorp/semgrep
     steps:
       - uses: actions/checkout@v4
-      - run: semgrep ci
+        with:
+          fetch-depth: 0
+      - run: semgrep ci --timeout 120 --timeout-threshold 3
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+          SEMGREP_TIMEOUT: "300"


### PR DESCRIPTION
- fetch-depth: 0 so semgrep can resolve the PR merge-base without needing to re-checkout / refetch refs
- per-rule timeout and threshold to skip pathological files instead of hanging the whole scan
- 20 min job timeout as a hard ceiling