### PR TITLE
refactor: remove emailDefaultLocale setting

### DIFF
--- a/prisma/migrations/20260504000000_remove_email_default_locale/migration.sql
+++ b/prisma/migrations/20260504000000_remove_email_default_locale/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Settings" DROP COLUMN "emailDefaultLocale";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,7 +182,6 @@ model Settings {
   emailVerificationRequired Boolean @default(false)
 
   // Email Templates
-  emailDefaultLocale        String  @default("en")
   shareEmailSubject         String?
   shareEmailHtml            String?
   shareEmailText            String?

--- a/src/app/api/admin/email-templates/route.ts
+++ b/src/app/api/admin/email-templates/route.ts
@@ -31,7 +31,6 @@ export async function GET(request: NextRequest) {
   try {
     const settings = await prisma.settings.findFirst({
       select: {
-        emailDefaultLocale: true,
         shareEmailSubject: true,
         shareEmailHtml: true,
         shareEmailText: true,
@@ -43,7 +42,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       templates: {
-        emailDefaultLocale: settings?.emailDefaultLocale ?? "en",
         shareEmailSubject: settings?.shareEmailSubject ?? null,
         shareEmailHtml: settings?.shareEmailHtml ?? null,
         shareEmailText: settings?.shareEmailText ?? null,
@@ -67,7 +65,6 @@ export async function GET(request: NextRequest) {
 }
 
 const TEMPLATE_FIELDS = [
-  "emailDefaultLocale",
   "shareEmailSubject",
   "shareEmailHtml",
   "shareEmailText",
@@ -89,7 +86,6 @@ function pickProvided(data: TemplateData) {
 
 function buildCreateData(data: TemplateData) {
   return {
-    emailDefaultLocale: data.emailDefaultLocale ?? "en",
     shareEmailSubject: data.shareEmailSubject ?? null,
     shareEmailHtml: data.shareEmailHtml ?? null,
     shareEmailText: data.shareEmailText ?? null,
@@ -101,7 +97,6 @@ function buildCreateData(data: TemplateData) {
 
 function pickTemplates<T extends TemplateData>(settings: T) {
   return {
-    emailDefaultLocale: settings.emailDefaultLocale,
     shareEmailSubject: settings.shareEmailSubject,
     shareEmailHtml: settings.shareEmailHtml,
     shareEmailText: settings.shareEmailText,

--- a/src/components/admin/EmailTemplatesTab.tsx
+++ b/src/components/admin/EmailTemplatesTab.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from "react-i18next";
 type EmailType = "share" | "verify";
 
 interface EmailTemplates {
-  emailDefaultLocale: string;
   shareEmailSubject: string | null;
   shareEmailHtml: string | null;
   shareEmailText: string | null;
@@ -31,13 +30,10 @@ interface PreviewResult {
   text: string;
 }
 
-const LOCALES = ["en", "fr", "es", "de", "nl", "pl"] as const;
-
 export default function EmailTemplatesTab() {
   const { t } = useTranslation();
   const [activeType, setActiveType] = useState<EmailType>("share");
   const [templates, setTemplates] = useState<EmailTemplates>({
-    emailDefaultLocale: "en",
     shareEmailSubject: null,
     shareEmailHtml: null,
     shareEmailText: null,
@@ -155,9 +151,7 @@ export default function EmailTemplatesTab() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const patchData: Partial<EmailTemplates> = {
-        emailDefaultLocale: templates.emailDefaultLocale,
-      };
+      const patchData: Partial<EmailTemplates> = {};
 
       if (activeType === "share") {
         patchData.shareEmailSubject = subject || null;
@@ -276,26 +270,6 @@ export default function EmailTemplatesTab() {
             "Customize the HTML/text content and subject line of outgoing emails. Use {{appName}}, {{shareTitle}}, {{shareUrl}}, or {{verifyUrl}} as placeholders."
           )}
         </p>
-      </div>
-
-      {/* Default locale selector */}
-      <div className="mb-6 flex items-center gap-3">
-        <label className="text-sm font-medium text-[var(--foreground)]">
-          {t("admin.email_templates.default_locale", "Default locale")}
-        </label>
-        <select
-          value={templates.emailDefaultLocale}
-          onChange={(e) =>
-            setTemplates((prev) => ({ ...prev, emailDefaultLocale: e.target.value }))
-          }
-          className="bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)] text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          {LOCALES.map((loc) => (
-            <option key={loc} value={loc}>
-              {loc.toUpperCase()}
-            </option>
-          ))}
-        </select>
       </div>
 
       {/* Email type tabs */}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -621,7 +621,6 @@
     "email_templates": {
       "title": "E-Mail-Vorlagen",
       "description": "Passen Sie den HTML-/Text-Inhalt und die Betreffzeile ausgehender E-Mails an. Verwenden Sie {{appName}}, {{shareTitle}}, {{shareUrl}} oder {{verifyUrl}} als Variablen.",
-      "default_locale": "Standardsprache",
       "type_share": "Freigabe-E-Mail",
       "type_verify": "Verifizierungs-E-Mail",
       "subject": "Betreff",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -625,7 +625,6 @@
     "email_templates": {
       "title": "Email Templates",
       "description": "Customize the HTML/text content and subject line of outgoing emails. Use {{appName}}, {{shareTitle}}, {{shareUrl}}, or {{verifyUrl}} as placeholders.",
-      "default_locale": "Default locale",
       "type_share": "Share Email",
       "type_verify": "Verification Email",
       "subject": "Subject",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -621,7 +621,6 @@
     "email_templates": {
       "title": "Plantillas de correo",
       "description": "Personalice el contenido HTML/texto y el asunto de los correos salientes. Use {{appName}}, {{shareTitle}}, {{shareUrl}} o {{verifyUrl}} como variables.",
-      "default_locale": "Idioma por defecto",
       "type_share": "Correo de compartir",
       "type_verify": "Correo de verificación",
       "subject": "Asunto",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -625,7 +625,6 @@
     "email_templates": {
       "title": "Modèles d'e-mail",
       "description": "Personnalisez le contenu HTML/texte et l'objet des e-mails sortants. Utilisez {{appName}}, {{shareTitle}}, {{shareUrl}} ou {{verifyUrl}} comme variables.",
-      "default_locale": "Langue par défaut",
       "type_share": "E-mail de partage",
       "type_verify": "E-mail de vérification",
       "subject": "Objet",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -628,7 +628,6 @@
     "email_templates": {
       "title": "E-mailsjablonen",
       "description": "Pas de HTML-/tekstinhoud en de onderwerpregel van uitgaande e-mails aan. Gebruik {{appName}}, {{shareTitle}}, {{shareUrl}} of {{verifyUrl}} als variabelen.",
-      "default_locale": "Standaardtaal",
       "type_share": "Deel-e-mail",
       "type_verify": "Verificatie-e-mail",
       "subject": "Onderwerp",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -625,7 +625,6 @@
     "email_templates": {
       "title": "Szablony e-mail",
       "description": "Dostosuj treść HTML/tekstową i temat wychodzących e-maili. Użyj {{appName}}, {{shareTitle}}, {{shareUrl}} lub {{verifyUrl}} jako zmiennych.",
-      "default_locale": "Domyślny język",
       "type_share": "E-mail udostępniania",
       "type_verify": "E-mail weryfikacyjny",
       "subject": "Temat",


### PR DESCRIPTION
## Description

Remove the `emailDefaultLocale` setting from the email templates system. This field was stored in the database but never actively used in the application logic. Removing it simplifies the email template configuration and reduces unnecessary database schema complexity.

Changes include:
- Removed `emailDefaultLocale` field from the Settings model and database schema
- Removed the default locale selector UI component from the email templates admin tab
- Removed the `LOCALES` constant that was only used for the locale dropdown
- Updated API endpoints to no longer handle this field
- Removed related translation strings from all locale files

## Type of Change

- [x] 🔧 **Refactor** (code change that neither fixes a bug nor adds a feature)

## Related Issues

<!-- Link related issues if applicable -->

## Checklist

### Code Quality

- [x] My code follows the coding standards
- [x] I have performed a self-review of my code
- [x] My code is properly typed (TypeScript)

### Testing

- [x] I have tested my changes locally
- [x] All existing tests pass
- [x] My changes do not break existing functionality

### Documentation

- [x] I have updated translation files to remove obsolete strings

### Security & Best Practices

- [x] My changes do not introduce security vulnerabilities
- [x] I have followed database migration best practices

## Additional Notes

This is a cleanup refactor that removes unused functionality. The `emailDefaultLocale` field was never utilized in the email sending logic, making it safe to remove. A database migration is included to drop the column from the Settings table.

https://claude.ai/code/session_017xgKEzW1tQQAVSiJt2KyjG