### PR TITLE
Add Gravatar support for user profile pictures

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   // Enable output as standalone to reduce runtime dependencies in Docker
+  allowedDevOrigins: ["3000.code.romain-pinsolle.fr"],
   output: "standalone",
   compress: true,
   serverExternalPackages: ["@prisma/client", "@prisma/adapter-pg", "pg"],

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -186,6 +186,7 @@ export default function Navigation() {
                   sx={{ p: 0 }}
                 >
                   <Avatar
+                    src={session.user?.image ?? undefined}
                     sx={{
                       background:
                         "linear-gradient(to bottom right, var(--primary), var(--secondary))",
@@ -344,6 +345,7 @@ export default function Navigation() {
           <List>
             <ListItem sx={{ py: 2, px: 2 }}>
               <Avatar
+                src={session.user?.image ?? undefined}
                 sx={{
                   background: "linear-gradient(to bottom right, var(--primary), var(--secondary))",
                   mr: 2,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import type { Prisma } from "@/generated/prisma";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { prisma } from "@/lib/prisma";
+import { gravatarUrl } from "@/lib/gravatar";
 import bcrypt from "bcryptjs";
 import { Provider } from "next-auth/providers/index";
 import { providerMap } from "./providers";
@@ -26,6 +27,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     id: string;
     name?: string | null;
+    image?: string | null;
   }
 }
 
@@ -292,6 +294,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         if (user) {
           token.id = user.id;
           token.name = user.name;
+          token.image = user.image || gravatarUrl(token.email as string);
         }
         return token;
       },
@@ -299,6 +302,7 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
         if (token && session.user) {
           session.user.id = token.id as string;
           session.user.name = token.name as string | null;
+          session.user.image = token.image as string | null;
         }
         return session;
       },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -296,6 +296,9 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
           token.name = user.name;
           token.image = user.image || gravatarUrl(token.email as string);
         }
+        if (!token.image && token.email) {
+          token.image = gravatarUrl(token.email as string);
+        }
         return token;
       },
       session: async ({ session, token }) => {

--- a/src/lib/gravatar.ts
+++ b/src/lib/gravatar.ts
@@ -1,0 +1,6 @@
+import { createHash } from "crypto";
+
+export function gravatarUrl(email: string, size = 80): string {
+  const hash = createHash("md5").update(email.trim().toLowerCase()).digest("hex");
+  return `https://www.gravatar.com/avatar/${hash}?s=${size}&d=mp`;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -46,7 +46,7 @@ function addSecurityHeaders(
       "default-src 'self'",
       `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://challenges.cloudflare.com https://stats.sheephost.fr https://www.google.com https://www.gstatic.com${isScalarHtml ? " https://cdn.jsdelivr.net" : ""}`,
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob:",
+      "img-src 'self' data: blob: https://www.gravatar.com",
       `font-src 'self' data:${isScalarHtml ? ` ${SCALAR_DOMAINS}` : ""}`,
       "frame-src 'self' https://challenges.cloudflare.com https://www.google.com",
       `connect-src 'self' https://challenges.cloudflare.com https://stats.sheephost.fr${isScalarHtml ? ` ${SCALAR_DOMAINS}` : ""}`,


### PR DESCRIPTION
## Summary

- Add Gravatar URL generation based on user email (MD5 hash)
- Fix token image fallback for existing sessions that predate this feature
- Allow `gravatar.com` in CSP `img-src` directive (was blocking avatar display)

## Test plan

- [ ] Se connecter avec un compte existant → avatar visible dans la navigation
- [ ] Se connecter avec un nouveau compte → Gravatar affiché si enregistré sur gravatar.com, sinon avatar par défaut
- [ ] Vérifier l'absence d'erreurs CSP liées à gravatar.com dans la console