### PR TITLE
feat: add S3-compatible object storage support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,22 @@ ALLOW_SIGNUP=true
 # AUTH_TRUST_HOST=true
 NODE_ENV=development
 
-# Upload directory
+# Upload directory (local storage)
 # Set to an absolute path to store uploaded files
 # Defaults to ./uploads in project root if not set
+# Ignored when S3_BUCKET is set
 UPLOAD_DIR=
+
+# S3-compatible object storage (optional)
+# When S3_BUCKET is set, files are stored in S3 instead of the local filesystem.
+# Compatible with AWS S3, MinIO, Garage, Cloudflare R2, Scaleway Object Storage, etc.
+#
+# S3_BUCKET=my-snowshare-bucket
+# S3_REGION=us-east-1
+# S3_ACCESS_KEY_ID=your-access-key
+# S3_SECRET_ACCESS_KEY=your-secret-key
+# Custom endpoint for self-hosted / S3-compatible services (MinIO, Garage, R2…)
+# S3_ENDPOINT=http://minio:9000
 
 # Telemetry (Plausible Analytics - privacy-friendly, GDPR compliant)
 # Set to "false" to disable analytics

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/superpowers
 e2e/.venv
 e2e/results
 .vscode/settings.json
+memory

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,13 @@
     "src/generated": true
   },
   "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
     "node_modules": true,
     ".next": true
-  }
+  },
+  "hide-files.files": []
 }

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,7 +5,7 @@ const config = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
-  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/"],
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/", "<rootDir>/.worktrees/"],
   transform: {
     "^.+\\.(ts|tsx)$": [
       "ts-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "snowshare",
-  "version": "1.4.3",
+  "version": "1.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "snowshare",
-      "version": "1.4.3",
+      "version": "1.4.5",
       "dependencies": {
         "@auth/prisma-adapter": "^2.10.0",
+        "@aws-sdk/client-s3": "^3.1044.0",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.3.4",
@@ -251,6 +252,860 @@
       "license": "MIT",
       "peerDependencies": {
         "preact": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1044.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1044.0.tgz",
+      "integrity": "sha512-yT3g0Oi0b+pJBJswNxRwWLLBoExQhRx9Iz2rUy1xV0slMogTQN+DSjChI95XTDtpGEcY0qnIK6UYX0XCYdhOKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.16",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.16.tgz",
+      "integrity": "sha512-6ru8doI0/XzszqLIPXf0E/V7HhAw1Pu94010XCKYtBUfD0LxF0BuOzrUf8OQGR6j2o6wgKTHUniOmndQycHwCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4420,6 +5275,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -5620,6 +6487,725 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -8010,6 +9596,12 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "license": "MIT",
@@ -10202,6 +11794,42 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -16314,6 +17942,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "dev": true,
@@ -18437,6 +20080,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",
+    "@aws-sdk/client-s3": "^3.1044.0",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.3.4",

--- a/prisma/migrations/20260513000000_add_s3_settings/migration.sql
+++ b/prisma/migrations/20260513000000_add_s3_settings/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "Settings" ADD COLUMN "s3Enabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Settings" ADD COLUMN "s3Endpoint" TEXT;
+ALTER TABLE "Settings" ADD COLUMN "s3Region" TEXT;
+ALTER TABLE "Settings" ADD COLUMN "s3Bucket" TEXT;
+ALTER TABLE "Settings" ADD COLUMN "s3AccessKeyId" TEXT;
+ALTER TABLE "Settings" ADD COLUMN "s3SecretAccessKey" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,6 +188,14 @@ model Settings {
   verifyEmailSubject        String?
   verifyEmailHtml           String?
   verifyEmailText           String?
+
+  // S3-compatible object storage
+  s3Enabled         Boolean @default(false)
+  s3Endpoint        String? // Custom endpoint (MinIO, etc.)
+  s3Region          String? // Defaults to "us-east-1"
+  s3Bucket          String?
+  s3AccessKeyId     String?
+  s3SecretAccessKey String?
 }
 
 model CustomLink {

--- a/scripts/cleanup-expired-shares.ts
+++ b/scripts/cleanup-expired-shares.ts
@@ -1,12 +1,6 @@
 #!/usr/bin/env node
 import { prisma } from "@/lib/prisma";
-import fs from "fs";
-import path from "path";
-
-// Get upload directory from env or default to ./uploads
-function getUploadDir(): string {
-  return process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
-}
+import { deleteFromStorage } from "@/lib/storage";
 
 async function cleanupExpiredShares() {
   console.log("🧹 Starting cleanup of expired shares...");
@@ -50,19 +44,13 @@ async function cleanupExpiredShares() {
       relativePath: string,
       shareSlug: string
     ): Promise<boolean> => {
-      const fullFilePath = path.join(getUploadDir(), relativePath);
-
       try {
-        await fs.promises.access(fullFilePath, fs.constants.F_OK);
-        await fs.promises.unlink(fullFilePath);
+        await deleteFromStorage(relativePath);
         deletedFiles++;
         console.log(`🗑️  File deleted: ${relativePath} (share: ${shareSlug})`);
         return true;
       } catch (error) {
-        // Access throws if the file does not exist; ignore ENOENT but surface other errors for visibility.
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          console.error(`❌ Error deleting file ${relativePath}:`, error);
-        }
+        console.error(`❌ Error deleting file ${relativePath}:`, error);
         return false;
       }
     };
@@ -80,7 +68,6 @@ async function cleanupExpiredShares() {
       }
     }
 
-    // Delete database records
     const deleteResult = await prisma.share.deleteMany({
       where: {
         expiresAt: {
@@ -100,7 +87,6 @@ async function cleanupExpiredShares() {
   }
 }
 
-// Execute the script if it is called directly
 const isMain =
   process.argv[1] &&
   (process.argv[1].endsWith("cleanup-expired-shares.ts") ||

--- a/scripts/cleanup-expired-shares.ts
+++ b/scripts/cleanup-expired-shares.ts
@@ -2,7 +2,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { prisma } from "@/lib/prisma";
-import { deleteFromStorage } from "@/lib/storage";
+import { deleteFromStorage, storageFileExists } from "@/lib/storage";
 
 function getUploadDir(): string {
   return process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
@@ -46,14 +46,13 @@ async function cleanupExpiredShares(): Promise<{ deletedShares: number; deletedF
   let deletedFiles = 0;
 
   const deleteFileIfExists = async (relativePath: string, shareSlug: string): Promise<void> => {
+    if (!(await storageFileExists(relativePath))) return;
     try {
       await deleteFromStorage(relativePath);
       deletedFiles++;
       console.log(`🗑️  File deleted: ${relativePath} (share: ${shareSlug})`);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        console.error(`❌ Error deleting file ${relativePath}:`, error);
-      }
+      console.error(`❌ Error deleting file ${relativePath}:`, error);
     }
   };
 

--- a/server.js
+++ b/server.js
@@ -188,6 +188,55 @@ async function calculateIpUsage(prisma, clientIp, uploadsDir) {
   return totalSize;
 }
 
+function resolveUploadLimits(settings, isAuthenticated) {
+  const maxFileSizeMB = isAuthenticated
+    ? settings?.authMaxUpload || 51200
+    : settings?.anoMaxUpload || 2048;
+  const ipQuotaMB = isAuthenticated
+    ? settings?.authIpQuota || 102400
+    : settings?.anoIpQuota || 4096;
+  return {
+    maxFileSizeBytes: maxFileSizeMB * 1024 * 1024,
+    ipQuotaBytes: ipQuotaMB * 1024 * 1024,
+  };
+}
+
+function parseAndClampExpiresAt(expiresAt, isAuthenticated) {
+  let parsed = null;
+  if (expiresAt) {
+    parsed = new Date(expiresAt);
+    if (isNaN(parsed.getTime())) parsed = null;
+  }
+  if (!isAuthenticated) {
+    const maxExpiry = new Date();
+    maxExpiry.setDate(maxExpiry.getDate() + MAX_ANON_EXPIRY_DAYS);
+    if (!parsed) return maxExpiry;
+    if (parsed > maxExpiry) return maxExpiry;
+  }
+  return parsed;
+}
+
+async function hashUploadPassword(password) {
+  if (!password) return null;
+  const bcrypt = await import("bcryptjs");
+  return bcrypt.default.hash(password, BCRYPT_COST);
+}
+
+async function resolveSlugOrGenerate(prisma, slug) {
+  let finalSlug = slug;
+  if (finalSlug && !SLUG_REGEX.test(finalSlug)) {
+    throw { status_code: 400, body: JSON.stringify({ error: "SLUG_INVALID" }) };
+  }
+  if (finalSlug) {
+    const existing = await prisma.share.findUnique({ where: { slug: finalSlug } });
+    if (existing) throw { status_code: 409, body: JSON.stringify({ error: "SLUG_ALREADY_TAKEN" }) };
+  }
+  if (!finalSlug) {
+    finalSlug = crypto.randomBytes(8).toString("hex").slice(0, 16);
+  }
+  return finalSlug;
+}
+
 // Ensure directories exist
 const uploadsDir = getUploadDir();
 const tusTempDir = getTusTempDir();
@@ -265,18 +314,7 @@ const tusServer = new TusServer({
 
     // Get settings
     const settings = await prisma.settings.findFirst();
-
-    let maxFileSizeMB, ipQuotaMB;
-    if (isAuthenticated) {
-      maxFileSizeMB = settings?.authMaxUpload || 51200;
-      ipQuotaMB = settings?.authIpQuota || 102400;
-    } else {
-      maxFileSizeMB = settings?.anoMaxUpload || 2048;
-      ipQuotaMB = settings?.anoIpQuota || 4096;
-    }
-
-    const maxFileSizeBytes = maxFileSizeMB * 1024 * 1024;
-    const ipQuotaBytes = ipQuotaMB * 1024 * 1024;
+    const { maxFileSizeBytes, ipQuotaBytes } = resolveUploadLimits(settings, isAuthenticated);
 
     // Check file size limit
     // upload.size property contains the size from the Upload-Length header
@@ -390,51 +428,9 @@ const tusServer = new TusServer({
           throw { status_code: 403, body: JSON.stringify(body) };
         }
       } else if (isBulk && fileIndex === 0) {
-        let finalSlug = slug;
-        if (finalSlug && !SLUG_REGEX.test(finalSlug)) {
-          const body = { error: "SLUG_INVALID" };
-          throw { status_code: 400, body: JSON.stringify(body) };
-        }
-
-        if (finalSlug) {
-          const existing = await prisma.share.findUnique({ where: { slug: finalSlug } });
-          if (existing) {
-            const body = { error: "SLUG_ALREADY_TAKEN" };
-            throw { status_code: 409, body: JSON.stringify(body) };
-          }
-        }
-        if (!finalSlug) {
-          finalSlug = crypto.randomBytes(8).toString("hex").slice(0, 16);
-        }
-
-        let parsedExpiresAt = null;
-        if (expiresAt) {
-          parsedExpiresAt = new Date(expiresAt);
-          if (isNaN(parsedExpiresAt.getTime())) {
-            parsedExpiresAt = null;
-          }
-        }
-
-        if (!isAuthenticated) {
-          const defaultExpiry = new Date();
-          defaultExpiry.setDate(defaultExpiry.getDate() + MAX_ANON_EXPIRY_DAYS);
-
-          if (!parsedExpiresAt) {
-            parsedExpiresAt = defaultExpiry;
-          } else {
-            const maxExpiry = new Date();
-            maxExpiry.setDate(maxExpiry.getDate() + MAX_ANON_EXPIRY_DAYS);
-            if (parsedExpiresAt > maxExpiry) {
-              parsedExpiresAt = maxExpiry;
-            }
-          }
-        }
-
-        let hashedPassword = null;
-        if (password) {
-          const bcrypt = await import("bcryptjs");
-          hashedPassword = await bcrypt.default.hash(password, BCRYPT_COST);
-        }
+        const finalSlug = await resolveSlugOrGenerate(prisma, slug);
+        const parsedExpiresAt = parseAndClampExpiresAt(expiresAt, isAuthenticated);
+        const hashedPassword = await hashUploadPassword(password);
 
         share = await prisma.share.create({
           data: {
@@ -451,51 +447,9 @@ const tusServer = new TusServer({
 
         console.log(`Created bulk share: ${share.slug}`);
       } else {
-        let finalSlug = slug;
-        if (finalSlug && !SLUG_REGEX.test(finalSlug)) {
-          const body = { error: "SLUG_INVALID" };
-          throw { status_code: 400, body: JSON.stringify(body) };
-        }
-
-        if (finalSlug) {
-          const existing = await prisma.share.findUnique({ where: { slug: finalSlug } });
-          if (existing) {
-            const body = { error: "SLUG_ALREADY_TAKEN" };
-            throw { status_code: 409, body: JSON.stringify(body) };
-          }
-        }
-        if (!finalSlug) {
-          finalSlug = crypto.randomBytes(8).toString("hex").slice(0, 16);
-        }
-
-        let parsedExpiresAt = null;
-        if (expiresAt) {
-          parsedExpiresAt = new Date(expiresAt);
-          if (isNaN(parsedExpiresAt.getTime())) {
-            parsedExpiresAt = null;
-          }
-        }
-
-        if (!isAuthenticated) {
-          const defaultExpiry = new Date();
-          defaultExpiry.setDate(defaultExpiry.getDate() + MAX_ANON_EXPIRY_DAYS);
-
-          if (!parsedExpiresAt) {
-            parsedExpiresAt = defaultExpiry;
-          } else {
-            const maxExpiry = new Date();
-            maxExpiry.setDate(maxExpiry.getDate() + MAX_ANON_EXPIRY_DAYS);
-            if (parsedExpiresAt > maxExpiry) {
-              parsedExpiresAt = maxExpiry;
-            }
-          }
-        }
-
-        let hashedPassword = null;
-        if (password) {
-          const bcrypt = await import("bcryptjs");
-          hashedPassword = await bcrypt.default.hash(password, BCRYPT_COST);
-        }
+        const finalSlug = await resolveSlugOrGenerate(prisma, slug);
+        const parsedExpiresAt = parseAndClampExpiresAt(expiresAt, isAuthenticated);
+        const hashedPassword = await hashUploadPassword(password);
 
         share = await prisma.share.create({
           data: {

--- a/server.js
+++ b/server.js
@@ -170,20 +170,27 @@ async function calculateIpUsage(prisma, clientIp, uploadsDir) {
   });
 
   let totalSize = 0;
+  const useS3 = !!process.env.S3_BUCKET;
+  let storageModule = null;
+  if (useS3) {
+    storageModule = await import("./src/lib/storage.js");
+  }
+
   for (const share of shares) {
     if (share.isBulk && share.files?.length > 0) {
-      // Bulk upload: sum ShareFile sizes
       for (const file of share.files) {
         totalSize += Number(file.size);
       }
     } else if (share.filePath) {
-      // Single upload: stat file on disk
-      const fullPath = path.join(uploadsDir, share.filePath);
       try {
-        const stats = await stat(fullPath);
-        totalSize += stats.size;
+        if (useS3 && storageModule) {
+          totalSize += await storageModule.getStorageFileSize(share.filePath);
+        } else {
+          const stats = await stat(path.join(uploadsDir, share.filePath));
+          totalSize += stats.size;
+        }
       } catch {
-        // File doesn't exist, skip
+        // File missing — skip
       }
     }
   }
@@ -525,8 +532,17 @@ const tusServer = new TusServer({
         await unlink(tusMetaPath);
       }
 
+      // Upload to S3 when configured, then remove the local copy
+      if (process.env.S3_BUCKET) {
+        const { uploadToStorage } = await import("./src/lib/storage.js");
+        await uploadToStorage(finalFilePath, finalFileName);
+        await unlink(finalFilePath);
+      }
+
       if (isBulk) {
-        const fileStats = await stat(finalFilePath);
+        const fileStats = process.env.S3_BUCKET
+          ? { size: upload.size ?? 0 }
+          : await stat(finalFilePath);
         // Re-validate the bulk share exists to avoid FK errors if it was removed between checks
         const currentShare = await prisma.share.findUnique({
           where: { id: share.id },

--- a/server.js
+++ b/server.js
@@ -170,11 +170,7 @@ async function calculateIpUsage(prisma, clientIp, uploadsDir) {
   });
 
   let totalSize = 0;
-  const useS3 = !!process.env.S3_BUCKET;
-  let storageModule = null;
-  if (useS3) {
-    storageModule = await import("./src/lib/storage.js");
-  }
+  const storageModule = await import("./src/lib/storage.js");
 
   for (const share of shares) {
     if (share.isBulk && share.files?.length > 0) {
@@ -183,12 +179,7 @@ async function calculateIpUsage(prisma, clientIp, uploadsDir) {
       }
     } else if (share.filePath) {
       try {
-        if (useS3 && storageModule) {
-          totalSize += await storageModule.getStorageFileSize(share.filePath);
-        } else {
-          const stats = await stat(path.join(uploadsDir, share.filePath));
-          totalSize += stats.size;
-        }
+        totalSize += await storageModule.getStorageFileSize(share.filePath);
       } catch {
         // File missing — skip
       }
@@ -389,12 +380,12 @@ const tusServer = new TusServer({
         }
 
         // Verify ownership: authenticated users must own the share, anonymous users must match IP
-        const ownsShare = isAuthenticated
-          ? share.ownerId === userId
-          : share.ipSource === clientIp;
+        const ownsShare = isAuthenticated ? share.ownerId === userId : share.ipSource === clientIp;
 
         if (!ownsShare) {
-          console.error(`[Upload] Unauthorized bulk share access attempt: ${bulkShareId} by ${isAuthenticated ? `user ${userId}` : `IP ${clientIp}`}`);
+          console.error(
+            `[Upload] Unauthorized bulk share access attempt: ${bulkShareId} by ${isAuthenticated ? `user ${userId}` : `IP ${clientIp}`}`
+          );
           const body = { error: "UNAUTHORIZED_SHARE_ACCESS" };
           throw { status_code: 403, body: JSON.stringify(body) };
         }
@@ -525,24 +516,25 @@ const tusServer = new TusServer({
       const finalFileName = await generateSafeFilename(filename, share.id);
       const finalFilePath = path.join(uploadsDir, finalFileName);
 
-      await rename(tusFilePath, finalFilePath);
-
       const tusMetaPath = `${tusFilePath}.json`;
+
+      const { uploadToStorage, isS3Enabled } = await import("./src/lib/storage.js");
+      const s3Active = await isS3Enabled();
+
+      if (s3Active) {
+        // Upload directly from tus temp — never touch uploads/
+        await uploadToStorage(tusFilePath, finalFileName);
+        await unlink(tusFilePath);
+      } else {
+        await rename(tusFilePath, finalFilePath);
+      }
+
       if (existsSync(tusMetaPath)) {
         await unlink(tusMetaPath);
       }
 
-      // Upload to S3 when configured, then remove the local copy
-      if (process.env.S3_BUCKET) {
-        const { uploadToStorage } = await import("./src/lib/storage.js");
-        await uploadToStorage(finalFilePath, finalFileName);
-        await unlink(finalFilePath);
-      }
-
       if (isBulk) {
-        const fileStats = process.env.S3_BUCKET
-          ? { size: upload.size ?? 0 }
-          : await stat(finalFilePath);
+        const fileStats = s3Active ? { size: upload.size ?? 0 } : await stat(finalFilePath);
         // Re-validate the bulk share exists to avoid FK errors if it was removed between checks
         const currentShare = await prisma.share.findUnique({
           where: { id: share.id },
@@ -551,7 +543,7 @@ const tusServer = new TusServer({
 
         if (!currentShare) {
           console.error(`[Upload] Bulk share disappeared before linking file: ${share.id}`);
-          await unlink(finalFilePath).catch(() => {});
+          if (!s3Active) await unlink(finalFilePath).catch(() => {});
           throw new Error("Bulk share no longer exists");
         }
 
@@ -572,7 +564,7 @@ const tusServer = new TusServer({
           );
         } catch (error) {
           // Clean up the file if we fail to persist the DB relation to avoid orphaned disk usage
-          await unlink(finalFilePath).catch(() => {});
+          if (!s3Active) await unlink(finalFilePath).catch(() => {});
           if (error?.code === "P2003") {
             console.error(
               `[Upload] FK constraint when linking bulk file to share ${share.id}:`,

--- a/server.js
+++ b/server.js
@@ -222,6 +222,150 @@ async function hashUploadPassword(password) {
   return bcrypt.default.hash(password, BCRYPT_COST);
 }
 
+async function checkUploadQuota(prisma, clientIp, uploadSize, maxFileSizeBytes, ipQuotaBytes) {
+  if (uploadSize === undefined || uploadSize === null) return;
+  if (uploadSize > maxFileSizeBytes) {
+    throw { status_code: 413, body: JSON.stringify({ error: "FILE_TOO_LARGE" }) };
+  }
+  let currentUsage = 0;
+  try {
+    currentUsage = await calculateIpUsage(prisma, clientIp, getUploadDir());
+  } catch (error) {
+    console.error("Error calculating IP usage:", error);
+  }
+  const remaining = ipQuotaBytes - currentUsage;
+  if (remaining <= 0 || uploadSize > remaining) {
+    throw { status_code: 429, body: JSON.stringify({ error: "IP_QUOTA_EXCEEDED" }) };
+  }
+}
+
+async function validateUploadSlug(prisma, slug, isBulkSubsequent) {
+  if (!slug) return;
+  if (!SLUG_REGEX.test(slug)) {
+    throw { status_code: 400, body: JSON.stringify({ error: "SLUG_INVALID" }) };
+  }
+  if (!isBulkSubsequent) {
+    const existing = await prisma.share.findUnique({ where: { slug } });
+    if (existing) throw { status_code: 409, body: JSON.stringify({ error: "SLUG_ALREADY_TAKEN" }) };
+  }
+}
+
+async function resolveUploadShare(
+  prisma,
+  { isBulk, bulkShareId, fileIndex, slug, password, expiresAt, maxViews },
+  { clientIp, userId, isAuthenticated }
+) {
+  if (isBulk && bulkShareId) {
+    const share = await prisma.share.findUnique({ where: { id: bulkShareId } });
+    if (!share) {
+      console.error(`[Upload] Bulk share not found: ${bulkShareId}`);
+      throw new Error("Bulk share not found");
+    }
+    const ownsShare = isAuthenticated ? share.ownerId === userId : share.ipSource === clientIp;
+    if (!ownsShare) {
+      console.error(
+        `[Upload] Unauthorized bulk share access: ${bulkShareId} by ${isAuthenticated ? `user ${userId}` : `IP ${clientIp}`}`
+      );
+      throw { status_code: 403, body: JSON.stringify({ error: "UNAUTHORIZED_SHARE_ACCESS" }) };
+    }
+    return share;
+  }
+
+  const finalSlug = await resolveSlugOrGenerate(prisma, slug);
+  const parsedExpiresAt = parseAndClampExpiresAt(expiresAt, isAuthenticated);
+  const hashedPassword = await hashUploadPassword(password);
+
+  if (isBulk && fileIndex === 0) {
+    const share = await prisma.share.create({
+      data: {
+        slug: finalSlug,
+        type: "FILE",
+        password: hashedPassword,
+        expiresAt: parsedExpiresAt,
+        ipSource: clientIp,
+        ownerId: userId || null,
+        isBulk: true,
+        maxViews,
+      },
+    });
+    console.log(`Created bulk share: ${share.slug}`);
+    return share;
+  }
+
+  return prisma.share.create({
+    data: {
+      slug: finalSlug,
+      type: "FILE",
+      filePath: "",
+      password: hashedPassword,
+      expiresAt: parsedExpiresAt,
+      ipSource: clientIp,
+      ownerId: userId || null,
+      isBulk: false,
+      maxViews,
+    },
+  });
+}
+
+async function finalizeUploadFile(
+  prisma,
+  upload,
+  share,
+  { filename, relativePath, fileIndex, totalFiles, filetype },
+  s3Active
+) {
+  const tusFilePath = path.join(tusTempDir, upload.id);
+  const finalFileName = await generateSafeFilename(filename, share.id);
+  const finalFilePath = path.join(uploadsDir, finalFileName);
+  const tusMetaPath = `${tusFilePath}.json`;
+
+  if (s3Active) {
+    const { uploadToStorage } = await import("./src/lib/storage.js");
+    await uploadToStorage(tusFilePath, finalFileName);
+    await unlink(tusFilePath);
+  } else {
+    await rename(tusFilePath, finalFilePath);
+  }
+  if (existsSync(tusMetaPath)) await unlink(tusMetaPath);
+
+  if (share.isBulk) {
+    const fileStats = s3Active ? { size: upload.size ?? 0 } : await stat(finalFilePath);
+    const currentShare = await prisma.share.findUnique({
+      where: { id: share.id },
+      select: { id: true, slug: true },
+    });
+    if (!currentShare) {
+      if (!s3Active) await unlink(finalFilePath).catch(() => {});
+      throw new Error("Bulk share no longer exists");
+    }
+    try {
+      await prisma.shareFile.create({
+        data: {
+          shareId: share.id,
+          filePath: finalFileName,
+          originalName: filename,
+          relativePath,
+          size: BigInt(fileStats.size),
+          mimeType: filetype || "application/octet-stream",
+        },
+      });
+      console.log(`Bulk upload file ${fileIndex + 1}/${totalFiles}: ${filename} -> ${share.slug}`);
+    } catch (error) {
+      if (!s3Active) await unlink(finalFilePath).catch(() => {});
+      if (error?.code === "P2003") {
+        console.error(`[Upload] FK constraint when linking bulk file to share ${share.id}:`, error);
+        throw new Error("Bulk share reference missing during file finalize");
+      }
+      throw error;
+    }
+  } else {
+    await prisma.share.update({ where: { id: share.id }, data: { filePath: finalFileName } });
+    console.log(`Upload complete: ${filename} -> ${share.slug}`);
+  }
+
+  return finalFileName;
+}
+
 async function resolveSlugOrGenerate(prisma, slug) {
   let finalSlug = slug;
   if (finalSlug && !SLUG_REGEX.test(finalSlug)) {
@@ -312,66 +456,17 @@ const tusServer = new TusServer({
       timestamp: Date.now(),
     });
 
-    // Get settings
     const settings = await prisma.settings.findFirst();
     const { maxFileSizeBytes, ipQuotaBytes } = resolveUploadLimits(settings, isAuthenticated);
+    await checkUploadQuota(prisma, clientIp, upload.size, maxFileSizeBytes, ipQuotaBytes);
 
-    // Check file size limit
-    // upload.size property contains the size from the Upload-Length header
-    // It might be undefined if Upload-Defer-Length: 1 is sent
-    const uploadSize = upload.size;
-
-    // If size is available, check it against limits
-    if (uploadSize !== undefined && uploadSize !== null) {
-      if (uploadSize > maxFileSizeBytes) {
-        const body = { error: "FILE_TOO_LARGE" };
-        throw { status_code: 413, body: JSON.stringify(body) };
-      }
-
-      // Check IP quota
-      let currentUsage;
-      try {
-        currentUsage = await calculateIpUsage(prisma, clientIp, uploadsDir);
-      } catch (error) {
-        console.error("Error calculating IP usage:", error);
-        currentUsage = 0;
-      }
-
-      const remainingQuota = ipQuotaBytes - currentUsage;
-
-      if (remainingQuota <= 0 || uploadSize > remainingQuota) {
-        const body = { error: "IP_QUOTA_EXCEEDED" };
-        throw { status_code: 429, body: JSON.stringify(body) };
-      }
-    } else {
-      // If size is NOT available (deferred length), checking quota is harder.
-      // For now, we allow start, but we should probably limit max content length header if possible
-    }
-
-    // Validate slug before upload starts
     const metadata = upload.metadata || {};
     const slug = metadata.slug?.trim();
     const isBulkSubsequent =
       metadata.isBulk === "true" &&
       (metadata.bulkShareId || (metadata.fileIndex && parseInt(metadata.fileIndex) > 0));
-    if (slug) {
-      if (!SLUG_REGEX.test(slug)) {
-        const body = { error: "SLUG_INVALID" };
-        throw { status_code: 400, body: JSON.stringify(body) };
-      }
-      // For subsequent bulk files the share (and its slug) was already created by file 0
-      if (!isBulkSubsequent) {
-        const existingShare = await prisma.share.findUnique({ where: { slug } });
-        if (existingShare) {
-          const body = { error: "SLUG_ALREADY_TAKEN" };
-          throw { status_code: 409, body: JSON.stringify(body) };
-        }
-      }
-    }
+    await validateUploadSlug(prisma, slug, isBulkSubsequent);
 
-    // metadata is provided by the client and persisted by tus
-    // Server-side metadata additions here are NOT persisted
-    // Authentication must be re-done in onUploadFinish
     return { res: null };
   },
 
@@ -407,135 +502,22 @@ const tusServer = new TusServer({
       // Clean up
       uploadMetadata.delete(uploadId);
 
-      let share;
+      const share = await resolveUploadShare(
+        prisma,
+        { isBulk, bulkShareId, fileIndex, slug, password, expiresAt, maxViews },
+        { clientIp, userId, isAuthenticated }
+      );
 
-      if (isBulk && bulkShareId) {
-        share = await prisma.share.findUnique({ where: { id: bulkShareId } });
-
-        if (!share) {
-          console.error(`[Upload] Bulk share not found: ${bulkShareId}`);
-          throw new Error("Bulk share not found");
-        }
-
-        // Verify ownership: authenticated users must own the share, anonymous users must match IP
-        const ownsShare = isAuthenticated ? share.ownerId === userId : share.ipSource === clientIp;
-
-        if (!ownsShare) {
-          console.error(
-            `[Upload] Unauthorized bulk share access attempt: ${bulkShareId} by ${isAuthenticated ? `user ${userId}` : `IP ${clientIp}`}`
-          );
-          const body = { error: "UNAUTHORIZED_SHARE_ACCESS" };
-          throw { status_code: 403, body: JSON.stringify(body) };
-        }
-      } else if (isBulk && fileIndex === 0) {
-        const finalSlug = await resolveSlugOrGenerate(prisma, slug);
-        const parsedExpiresAt = parseAndClampExpiresAt(expiresAt, isAuthenticated);
-        const hashedPassword = await hashUploadPassword(password);
-
-        share = await prisma.share.create({
-          data: {
-            slug: finalSlug,
-            type: "FILE",
-            password: hashedPassword,
-            expiresAt: parsedExpiresAt,
-            ipSource: clientIp,
-            ownerId: userId || null,
-            isBulk: true,
-            maxViews,
-          },
-        });
-
-        console.log(`Created bulk share: ${share.slug}`);
-      } else {
-        const finalSlug = await resolveSlugOrGenerate(prisma, slug);
-        const parsedExpiresAt = parseAndClampExpiresAt(expiresAt, isAuthenticated);
-        const hashedPassword = await hashUploadPassword(password);
-
-        share = await prisma.share.create({
-          data: {
-            slug: finalSlug,
-            type: "FILE",
-            filePath: "",
-            password: hashedPassword,
-            expiresAt: parsedExpiresAt,
-            ipSource: clientIp,
-            ownerId: userId || null,
-            isBulk: false,
-            maxViews,
-          },
-        });
-      }
-
-      const tusFilePath = path.join(tusTempDir, upload.id);
-      const finalFileName = await generateSafeFilename(filename, share.id);
-      const finalFilePath = path.join(uploadsDir, finalFileName);
-
-      const tusMetaPath = `${tusFilePath}.json`;
-
-      const { uploadToStorage, isS3Enabled } = await import("./src/lib/storage.js");
+      const { isS3Enabled } = await import("./src/lib/storage.js");
       const s3Active = await isS3Enabled();
 
-      if (s3Active) {
-        // Upload directly from tus temp — never touch uploads/
-        await uploadToStorage(tusFilePath, finalFileName);
-        await unlink(tusFilePath);
-      } else {
-        await rename(tusFilePath, finalFilePath);
-      }
-
-      if (existsSync(tusMetaPath)) {
-        await unlink(tusMetaPath);
-      }
-
-      if (isBulk) {
-        const fileStats = s3Active ? { size: upload.size ?? 0 } : await stat(finalFilePath);
-        // Re-validate the bulk share exists to avoid FK errors if it was removed between checks
-        const currentShare = await prisma.share.findUnique({
-          where: { id: share.id },
-          select: { id: true, slug: true },
-        });
-
-        if (!currentShare) {
-          console.error(`[Upload] Bulk share disappeared before linking file: ${share.id}`);
-          if (!s3Active) await unlink(finalFilePath).catch(() => {});
-          throw new Error("Bulk share no longer exists");
-        }
-
-        try {
-          await prisma.shareFile.create({
-            data: {
-              shareId: share.id,
-              filePath: finalFileName,
-              originalName: filename,
-              relativePath: relativePath,
-              size: BigInt(fileStats.size),
-              mimeType: metadata.filetype || "application/octet-stream",
-            },
-          });
-
-          console.log(
-            `Bulk upload file ${fileIndex + 1}/${totalFiles}: ${filename} -> ${share.slug}`
-          );
-        } catch (error) {
-          // Clean up the file if we fail to persist the DB relation to avoid orphaned disk usage
-          if (!s3Active) await unlink(finalFilePath).catch(() => {});
-          if (error?.code === "P2003") {
-            console.error(
-              `[Upload] FK constraint when linking bulk file to share ${share.id}:`,
-              error
-            );
-            throw new Error("Bulk share reference missing during file finalize");
-          }
-          throw error;
-        }
-      } else {
-        await prisma.share.update({
-          where: { id: share.id },
-          data: { filePath: finalFileName },
-        });
-
-        console.log(`Upload complete: ${filename} -> ${share.slug}`);
-      }
+      await finalizeUploadFile(
+        prisma,
+        upload,
+        share,
+        { filename, relativePath, fileIndex, totalFiles, filetype: metadata.filetype },
+        s3Active
+      );
 
       return {
         headers: {

--- a/src/__tests__/api/download/download-streaming.test.ts
+++ b/src/__tests__/api/download/download-streaming.test.ts
@@ -11,13 +11,9 @@ jest.mock("@/app/api/shares/(fileShare)/fileshare", () => ({
   getFileShare: jest.fn(),
 }));
 
-jest.mock("fs", () => ({
-  createReadStream: jest.fn(),
-  existsSync: jest.fn(),
-}));
-
-jest.mock("fs/promises", () => ({
-  stat: jest.fn(),
+jest.mock("@/lib/storage", () => ({
+  getStorageReadStream: jest.fn(),
+  getStorageFileSize: jest.fn(),
 }));
 
 jest.mock("@/lib/mime-types", () => ({
@@ -32,15 +28,13 @@ jest.mock("@/lib/i18n-server", () => ({
 }));
 
 import { getFileShare } from "@/app/api/shares/(fileShare)/fileshare";
-import { createReadStream, existsSync } from "fs";
-import { stat } from "fs/promises";
+import { getStorageReadStream, getStorageFileSize } from "@/lib/storage";
 import { Readable } from "stream";
 import { NextRequest } from "next/server";
 
 const mockGetFileShare = getFileShare as jest.Mock;
-const mockCreateReadStream = createReadStream as jest.Mock;
-const mockExistsSync = existsSync as jest.Mock;
-const mockStat = stat as jest.Mock;
+const mockGetStorageReadStream = getStorageReadStream as jest.Mock;
+const mockGetStorageFileSize = getStorageFileSize as jest.Mock;
 
 function makeRequest(headers: Record<string, string> = {}, slug = "test-slug"): NextRequest {
   return {
@@ -55,40 +49,41 @@ function makeRequest(headers: Record<string, string> = {}, slug = "test-slug"): 
   } as unknown as NextRequest;
 }
 
+function makeReadableStream(): Readable {
+  return new Readable({
+    read() {
+      this.push("data");
+      this.push(null);
+    },
+  });
+}
+
 describe("File Download Streaming", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockExistsSync.mockReturnValue(true);
-    mockStat.mockResolvedValue({ size: 1000000 });
+    mockGetStorageFileSize.mockResolvedValue(1000000);
     mockGetFileShare.mockResolvedValue({
-      filePath: "/uploads/share-123_file.txt",
+      storageKey: "share-123_file.txt",
       originalFilename: "file.txt",
     });
-
-    const mockStream = new Readable({
-      read() {
-        this.push("data");
-        this.push(null);
-      },
-    });
-    mockCreateReadStream.mockReturnValue(mockStream);
+    mockGetStorageReadStream.mockResolvedValue(makeReadableStream());
   });
 
-  it("should use streaming (createReadStream) instead of loading the entire file into memory", async () => {
+  it("should use streaming (getStorageReadStream) instead of loading the entire file into memory", async () => {
     const { GET } = await import("@/app/api/download/[slug]/route");
     const request = makeRequest({}, "test-slug");
 
     await GET(request, { params: Promise.resolve({ slug: "test-slug" }) });
 
-    expect(mockCreateReadStream).toHaveBeenCalledWith("/uploads/share-123_file.txt");
-    expect(mockCreateReadStream).toHaveBeenCalledTimes(1);
+    expect(mockGetStorageReadStream).toHaveBeenCalledWith("share-123_file.txt");
+    expect(mockGetStorageReadStream).toHaveBeenCalledTimes(1);
   });
 
   it("should support range requests for resumable downloads", async () => {
     const fileSize = 10000000;
-    mockStat.mockResolvedValue({ size: fileSize });
+    mockGetStorageFileSize.mockResolvedValue(fileSize);
     mockGetFileShare.mockResolvedValue({
-      filePath: "/uploads/share-456_large.bin",
+      storageKey: "share-456_large.bin",
       originalFilename: "large.bin",
     });
 
@@ -97,8 +92,8 @@ describe("File Download Streaming", () => {
 
     await GET(request, { params: Promise.resolve({ slug: "large-file-slug" }) });
 
-    expect(mockCreateReadStream).toHaveBeenCalledWith(
-      "/uploads/share-456_large.bin",
+    expect(mockGetStorageReadStream).toHaveBeenCalledWith(
+      "share-456_large.bin",
       expect.objectContaining({ start: 0, end: 999999 })
     );
   });
@@ -112,12 +107,11 @@ describe("File Download Streaming", () => {
     const response = await GET(request, { params: Promise.resolve({ slug: "missing-slug" }) });
 
     expect(response.status).toBe(404);
-    expect(mockCreateReadStream).not.toHaveBeenCalled();
+    expect(mockGetStorageReadStream).not.toHaveBeenCalled();
   });
 
   it("should return 416 for an invalid range header", async () => {
-    // Range header beyond file size
-    mockStat.mockResolvedValue({ size: 100 });
+    mockGetStorageFileSize.mockResolvedValue(100);
 
     const { GET } = await import("@/app/api/download/[slug]/route");
     const request = makeRequest({ range: "bytes=500-999" }, "test-slug");
@@ -125,11 +119,11 @@ describe("File Download Streaming", () => {
     const response = await GET(request, { params: Promise.resolve({ slug: "test-slug" }) });
 
     expect(response.status).toBe(416);
-    expect(mockCreateReadStream).not.toHaveBeenCalled();
+    expect(mockGetStorageReadStream).not.toHaveBeenCalled();
   });
 
-  it("should confirm createReadStream is available as a streaming API", () => {
-    expect(mockCreateReadStream).toBeDefined();
-    expect(typeof mockCreateReadStream).toBe("function");
+  it("should confirm getStorageReadStream is available as a streaming API", () => {
+    expect(mockGetStorageReadStream).toBeDefined();
+    expect(typeof mockGetStorageReadStream).toBe("function");
   });
 });

--- a/src/__tests__/api/shares/fileshare.test.ts
+++ b/src/__tests__/api/shares/fileshare.test.ts
@@ -26,20 +26,21 @@ jest.mock("bcryptjs", () => ({
   ),
 }));
 
-jest.mock("fs", () => ({
-  existsSync: jest.fn(() => true),
+jest.mock("@/lib/storage", () => ({
+  storageFileExists: jest.fn(() => Promise.resolve(true)),
+  isS3Enabled: jest.fn(() => false),
 }));
 
 import { getFileShare } from "@/app/api/shares/(fileShare)/fileshare";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
-import { existsSync } from "fs";
+import { storageFileExists } from "@/lib/storage";
 import { ErrorCode } from "@/lib/api-errors";
 
 const mockPrismaFindUnique = prisma.share.findUnique as jest.Mock;
 const mockShareFileFindMany = prisma.shareFile.findMany as jest.Mock;
 const mockBcryptCompare = bcrypt.compare as jest.Mock;
-const mockExistsSync = existsSync as jest.Mock;
+const mockStorageFileExists = storageFileExists as jest.Mock;
 
 const baseShare = {
   id: "share-123",
@@ -56,7 +57,7 @@ const baseShare = {
 describe("getFileShare", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockExistsSync.mockReturnValue(true);
+    mockStorageFileExists.mockResolvedValue(true);
     mockPrismaFindUnique.mockResolvedValue(baseShare);
   });
 
@@ -135,19 +136,19 @@ describe("getFileShare", () => {
       expect(result.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
     });
 
-    it("should return FILE_NOT_FOUND if the physical file does not exist on disk", async () => {
-      mockExistsSync.mockReturnValue(false);
+    it("should return FILE_NOT_FOUND if the file does not exist in storage", async () => {
+      mockStorageFileExists.mockResolvedValue(false);
       const result = await getFileShare("my-share");
       expect(result.errorCode).toBe(ErrorCode.FILE_NOT_FOUND);
     });
   });
 
   describe("successful retrieval", () => {
-    it("should return share data, filePath, and originalFilename", async () => {
+    it("should return share data, storageKey, and originalFilename", async () => {
       const result = await getFileShare("my-share");
       expect(result.errorCode).toBeUndefined();
       expect(result.share).toMatchObject({ id: "share-123", slug: "my-share" });
-      expect(result.filePath).toContain("uploads");
+      expect(result.storageKey).toBe("share-123_document.pdf");
       expect(result.originalFilename).toBe("document.pdf");
     });
 

--- a/src/app/(shares)/f/[slug]/api/route.ts
+++ b/src/app/(shares)/f/[slug]/api/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFileShare } from "@/app/api/shares/(fileShare)/fileshare";
-import { existsSync } from "fs";
-import { stat } from "fs/promises";
+import { getStorageReadStream, getStorageFileSize } from "@/lib/storage";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { getMimeType, isSafeForInline, sanitizeFilenameForHeader } from "@/lib/mime-types";
 import { detectLocale, translate } from "@/lib/i18n-server";
 import { prisma } from "@/lib/prisma";
+import path from "path";
 
 // Handle POST requests for file info and download actions
 export async function POST(
@@ -33,7 +33,6 @@ export async function POST(
 
   try {
     if (action === "info") {
-      // Get file info without password first to check if password is required
       const result = await getFileShare(slug);
 
       if (result.errorCode && !result.requiresPassword) {
@@ -71,16 +70,16 @@ export async function POST(
         });
       }
 
-      const { filePath: fullPath, originalFilename } = result;
-      if (!fullPath || !existsSync(fullPath)) {
+      const { storageKey, originalFilename } = result;
+      if (!storageKey) {
         return apiError(request, ErrorCode.FILE_NOT_FOUND);
       }
 
-      const stats = await stat(fullPath);
+      const fileSize = await getStorageFileSize(storageKey);
 
       return NextResponse.json({
         filename: originalFilename,
-        fileSize: stats.size,
+        fileSize,
         requiresPassword: false,
         isBulk: false,
       });
@@ -93,7 +92,6 @@ export async function POST(
         return apiError(request, result.errorCode);
       }
 
-      // Increment view count
       if (result.share) {
         await prisma.share.update({
           where: { id: result.share.id },
@@ -106,9 +104,7 @@ export async function POST(
         return NextResponse.json({ downloadUrl, isBulk: true });
       }
 
-      const { filePath: fullPath } = result;
-
-      if (!fullPath || !existsSync(fullPath)) {
+      if (!result.storageKey) {
         return apiError(request, ErrorCode.FILE_NOT_FOUND);
       }
 
@@ -133,14 +129,12 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   try {
-    // Get password from query params if provided
     const url = new URL(request.url);
     const password = url.searchParams.get("password") || undefined;
 
     const result = await getFileShare(slug, password);
 
     if (result.errorCode) {
-      // If password required, redirect to the page for password input
       if (result.requiresPassword && !password) {
         const pageUrl = new URL(`/f/${slug}`, url.origin);
         return Response.redirect(pageUrl.toString(), 302);
@@ -149,25 +143,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return apiError(request, result.errorCode);
     }
 
-    const { filePath: fullPath, originalFilename } = result;
+    const { storageKey, originalFilename } = result;
 
-    if (!fullPath || !existsSync(fullPath)) {
+    if (!storageKey) {
       return apiError(request, ErrorCode.FILE_NOT_FOUND);
     }
 
-    // Get file stats for size
-    const stats = await stat(fullPath);
-    const fileSize = stats.size;
-
-    // Determine content type
-    const ext = (await import("path")).extname(fullPath).toLowerCase();
+    const fileSize = await getStorageFileSize(storageKey);
+    const ext = path.extname(storageKey).toLowerCase();
     const contentType = getMimeType(ext);
-
-    // Sanitize filename for Content-Disposition header
     const safeFilename = sanitizeFilenameForHeader(originalFilename || "download");
 
-    // Handle range request for resumable downloads
-    const { createReadStream } = await import("fs");
     const { nodeStreamToWebStream, parseRangeHeader } = await import("@/lib/stream-utils");
     const range = request.headers.get("range");
 
@@ -183,7 +169,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
       const { start, end } = rangeResult;
       const chunksize = end - start + 1;
-      const fileStream = createReadStream(fullPath, { start, end });
+      const fileStream = await getStorageReadStream(storageKey, { start, end });
       const webStream = nodeStreamToWebStream(fileStream);
 
       const headers = new Headers();
@@ -202,25 +188,24 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       });
     }
 
-    // Full file download using streaming
-    const fileStream = createReadStream(fullPath);
+    const fileStream = await getStorageReadStream(storageKey);
     const webStream = nodeStreamToWebStream(fileStream);
 
     const headers = new Headers();
     headers.set("Content-Length", fileSize.toString());
     headers.set("Content-Type", contentType);
-    headers.set("Content-Disposition", `attachment; filename="${safeFilename}"`);
     headers.set("Accept-Ranges", "bytes");
     headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
     headers.set("Pragma", "no-cache");
     headers.set("Expires", "0");
 
-    // Allow inline viewing only for safe types (excludes SVG/HTML to prevent XSS)
     if (isSafeForInline(contentType)) {
       const disposition = request.headers.get("accept")?.includes("text/html")
         ? "inline"
         : "attachment";
       headers.set("Content-Disposition", `${disposition}; filename="${safeFilename}"`);
+    } else {
+      headers.set("Content-Disposition", `attachment; filename="${safeFilename}"`);
     }
 
     return new NextResponse(webStream as ReadableStream<Uint8Array>, {

--- a/src/app/(shares)/f/[slug]/download/route.ts
+++ b/src/app/(shares)/f/[slug]/download/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFileShare } from "@/app/api/shares/(fileShare)/fileshare";
-import { createReadStream, existsSync } from "fs";
-import { stat } from "fs/promises";
-import path from "path";
+import { getStorageReadStream, getStorageFileSize } from "@/lib/storage";
 import { nodeStreamToWebStream, parseRangeHeader } from "@/lib/stream-utils";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { getMimeType, sanitizeFilenameForHeader } from "@/lib/mime-types";
+import path from "path";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -34,20 +33,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       );
     }
 
-    const { filePath: fullPath, originalFilename } = result;
+    const { storageKey, originalFilename } = result;
 
-    if (!fullPath || !existsSync(fullPath)) {
+    if (!storageKey) {
       return apiError(request, ErrorCode.FILE_NOT_FOUND);
     }
 
-    const stats = await stat(fullPath);
-    const fileSize = stats.size;
-
-    const ext = path.extname(fullPath).toLowerCase();
+    const fileSize = await getStorageFileSize(storageKey);
+    const ext = path.extname(storageKey).toLowerCase();
     const contentType = getMimeType(ext);
     const safeFilename = sanitizeFilenameForHeader(originalFilename || "download");
 
-    // Handle range request
     const range = request.headers.get("range");
 
     if (range) {
@@ -62,7 +58,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
       const { start, end } = rangeResult;
       const chunksize = end - start + 1;
-      const fileStream = createReadStream(fullPath, { start, end });
+      const fileStream = await getStorageReadStream(storageKey, { start, end });
       const webStream = nodeStreamToWebStream(fileStream);
 
       const headers = new Headers();
@@ -81,8 +77,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       });
     }
 
-    // Full file download
-    const fileStream = createReadStream(fullPath);
+    const fileStream = await getStorageReadStream(storageKey);
     const webStream = nodeStreamToWebStream(fileStream);
 
     const headers = new Headers();

--- a/src/app/(shares)/f/[slug]/file-preview/route.ts
+++ b/src/app/(shares)/f/[slug]/file-preview/route.ts
@@ -2,9 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
 import path from "path";
-import { existsSync, createReadStream } from "fs";
-import { stat } from "fs/promises";
-import { getUploadDir } from "@/lib/constants";
+import { getStorageReadStream, getStorageFileSize, storageFileExists } from "@/lib/storage";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { nodeStreamToWebStream } from "@/lib/stream-utils";
 import { getMimeType, isSafeForInline, sanitizeFilenameForHeader } from "@/lib/mime-types";
@@ -25,12 +23,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return apiError(request, ErrorCode.INVALID_REQUEST);
     }
 
-    // Security: Prevent path traversal attempts and validate input
     if (relativePath.includes("..") || relativePath.startsWith("/") || relativePath.length > 500) {
       return apiError(request, ErrorCode.INVALID_REQUEST);
     }
 
-    // Get the share
     const share = await prisma.share.findUnique({
       where: { slug },
       select: {
@@ -50,7 +46,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return apiError(request, ErrorCode.SHARE_EXPIRED);
     }
 
-    // Check password if required
     if (share.password) {
       if (!password) {
         return apiError(request, ErrorCode.PASSWORD_REQUIRED);
@@ -62,7 +57,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       }
     }
 
-    // Find the specific file in the share
     const shareFile = await prisma.shareFile.findFirst({
       where: {
         shareId: share.id,
@@ -80,28 +74,21 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return apiError(request, ErrorCode.FILE_NOT_FOUND);
     }
 
-    const fullPath = path.join(getUploadDir(), shareFile.filePath);
-
-    if (!existsSync(fullPath)) {
+    if (!(await storageFileExists(shareFile.filePath))) {
       return apiError(request, ErrorCode.FILE_NOT_FOUND);
     }
 
-    const stats = await stat(fullPath);
-    const fileSize = stats.size;
+    const fileSize = await getStorageFileSize(shareFile.filePath);
 
-    // Determine content type from mimeType or extension
     let contentType = shareFile.mimeType || "application/octet-stream";
-
     if (!shareFile.mimeType) {
-      const ext = path.extname(fullPath).toLowerCase();
+      const ext = path.extname(shareFile.filePath).toLowerCase();
       contentType = getMimeType(ext);
     }
 
-    // Sanitize filename for Content-Disposition header
     const safeFilename = sanitizeFilenameForHeader(shareFile.originalName || "download");
 
-    // Stream the file
-    const fileStream = createReadStream(fullPath);
+    const fileStream = await getStorageReadStream(shareFile.filePath);
     const webStream = nodeStreamToWebStream(fileStream);
 
     const headers = new Headers();
@@ -110,7 +97,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     headers.set("Accept-Ranges", "bytes");
     headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
 
-    // Allow inline viewing only for safe types (excludes SVG/HTML to prevent XSS)
     if (isSafeForInline(contentType)) {
       headers.set("Content-Disposition", `inline; filename="${safeFilename}"`);
     } else {

--- a/src/app/(shares)/f/[slug]/file-preview/route.ts
+++ b/src/app/(shares)/f/[slug]/file-preview/route.ts
@@ -7,6 +7,58 @@ import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { nodeStreamToWebStream } from "@/lib/stream-utils";
 import { getMimeType, isSafeForInline, sanitizeFilenameForHeader } from "@/lib/mime-types";
 
+type ShareAccess = {
+  id: string;
+  type: string;
+  password: string | null;
+  expiresAt: Date | null;
+  isBulk: boolean;
+} | null;
+
+async function validateShareAccess(
+  request: NextRequest,
+  share: ShareAccess,
+  password: string | undefined
+): Promise<NextResponse | null> {
+  if (!share || share.type !== "FILE" || !share.isBulk) {
+    return apiError(request, ErrorCode.SHARE_NOT_FOUND);
+  }
+  if (share.expiresAt && new Date(share.expiresAt) <= new Date()) {
+    return apiError(request, ErrorCode.SHARE_EXPIRED);
+  }
+  if (share.password) {
+    if (!password) return apiError(request, ErrorCode.PASSWORD_REQUIRED);
+    const valid = await bcrypt.compare(password, share.password);
+    if (!valid) return apiError(request, ErrorCode.PASSWORD_INCORRECT);
+  }
+  return null;
+}
+
+async function buildFileResponse(
+  shareFile: { filePath: string; originalName: string | null; mimeType: string | null },
+  fileSize: number
+): Promise<NextResponse> {
+  let contentType = shareFile.mimeType || "application/octet-stream";
+  if (!shareFile.mimeType) {
+    contentType = getMimeType(path.extname(shareFile.filePath).toLowerCase());
+  }
+  const safeFilename = sanitizeFilenameForHeader(shareFile.originalName || "download");
+  const fileStream = await getStorageReadStream(shareFile.filePath);
+  const webStream = nodeStreamToWebStream(fileStream);
+
+  const headers = new Headers();
+  headers.set("Content-Length", fileSize.toString());
+  headers.set("Content-Type", contentType);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
+  headers.set(
+    "Content-Disposition",
+    `${isSafeForInline(contentType) ? "inline" : "attachment"}; filename="${safeFilename}"`
+  );
+
+  return new NextResponse(webStream as ReadableStream<Uint8Array>, { status: 200, headers });
+}
+
 export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
 
@@ -29,84 +81,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const share = await prisma.share.findUnique({
       where: { slug },
-      select: {
-        id: true,
-        type: true,
-        password: true,
-        expiresAt: true,
-        isBulk: true,
-      },
+      select: { id: true, type: true, password: true, expiresAt: true, isBulk: true },
     });
 
-    if (!share || share.type !== "FILE" || !share.isBulk) {
-      return apiError(request, ErrorCode.SHARE_NOT_FOUND);
-    }
-
-    if (share.expiresAt && new Date(share.expiresAt) <= new Date()) {
-      return apiError(request, ErrorCode.SHARE_EXPIRED);
-    }
-
-    if (share.password) {
-      if (!password) {
-        return apiError(request, ErrorCode.PASSWORD_REQUIRED);
-      }
-
-      const passwordValid = await bcrypt.compare(password, share.password);
-      if (!passwordValid) {
-        return apiError(request, ErrorCode.PASSWORD_INCORRECT);
-      }
-    }
+    const accessError = await validateShareAccess(request, share, password);
+    if (accessError) return accessError;
 
     const shareFile = await prisma.shareFile.findFirst({
-      where: {
-        shareId: share.id,
-        relativePath: relativePath,
-      },
-      select: {
-        filePath: true,
-        originalName: true,
-        mimeType: true,
-        size: true,
-      },
+      where: { shareId: share!.id, relativePath },
+      select: { filePath: true, originalName: true, mimeType: true, size: true },
     });
 
-    if (!shareFile) {
-      return apiError(request, ErrorCode.FILE_NOT_FOUND);
-    }
-
-    if (!(await storageFileExists(shareFile.filePath))) {
+    if (!shareFile || !(await storageFileExists(shareFile.filePath))) {
       return apiError(request, ErrorCode.FILE_NOT_FOUND);
     }
 
     const fileSize = await getStorageFileSize(shareFile.filePath);
-
-    let contentType = shareFile.mimeType || "application/octet-stream";
-    if (!shareFile.mimeType) {
-      const ext = path.extname(shareFile.filePath).toLowerCase();
-      contentType = getMimeType(ext);
-    }
-
-    const safeFilename = sanitizeFilenameForHeader(shareFile.originalName || "download");
-
-    const fileStream = await getStorageReadStream(shareFile.filePath);
-    const webStream = nodeStreamToWebStream(fileStream);
-
-    const headers = new Headers();
-    headers.set("Content-Length", fileSize.toString());
-    headers.set("Content-Type", contentType);
-    headers.set("Accept-Ranges", "bytes");
-    headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
-
-    if (isSafeForInline(contentType)) {
-      headers.set("Content-Disposition", `inline; filename="${safeFilename}"`);
-    } else {
-      headers.set("Content-Disposition", `attachment; filename="${safeFilename}"`);
-    }
-
-    return new NextResponse(webStream as ReadableStream<Uint8Array>, {
-      status: 200,
-      headers,
-    });
+    return buildFileResponse(shareFile, fileSize);
   } catch (error) {
     console.error("File preview error:", error);
     return internalError(request);

--- a/src/app/api/admin/logs/[id]/route.ts
+++ b/src/app/api/admin/logs/[id]/route.ts
@@ -2,9 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { getUploadDir } from "@/lib/constants";
-import { unlink } from "fs/promises";
-import path from "path";
+import { deleteFromStorage } from "@/lib/storage";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 
 export async function DELETE(
@@ -38,9 +36,7 @@ export async function DELETE(
 
     if (share.type === "FILE" && share.filePath) {
       try {
-        const uploadDir = getUploadDir();
-        const filePath = path.join(uploadDir, share.filePath);
-        await unlink(filePath);
+        await deleteFromStorage(share.filePath);
       } catch (error) {
         console.error("Error deleting file:", error);
       }

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -3,6 +3,90 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { NextRequest, NextResponse } from "next/server";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
+import type { Settings } from "@/generated/prisma";
+
+type SettingsInput = Record<string, unknown>;
+
+function field<K extends keyof Settings>(
+  data: SettingsInput,
+  current: Settings,
+  key: K
+): Settings[K] {
+  return key in data && data[key] !== undefined ? (data[key] as Settings[K]) : current[key];
+}
+
+function nullableString<K extends keyof Settings>(
+  data: SettingsInput,
+  current: Settings,
+  key: K
+): Settings[K] {
+  return key in data && data[key] !== undefined
+    ? (((data[key] as string) || null) as Settings[K])
+    : current[key];
+}
+
+function maskedSecret<K extends keyof Settings>(
+  data: SettingsInput,
+  current: Settings,
+  key: K
+): Settings[K] {
+  const val = data[key];
+  if (val !== undefined && val !== "••••••••") return ((val as string) || null) as Settings[K];
+  return current[key];
+}
+
+function buildSettingsUpdateData(data: SettingsInput, current: Settings) {
+  return {
+    allowSignin: field(data, current, "allowSignin"),
+    disableCredentialsLogin: field(data, current, "disableCredentialsLogin"),
+    allowAnonFileShare: field(data, current, "allowAnonFileShare"),
+    allowAnonLinkShare: field(data, current, "allowAnonLinkShare"),
+    allowAnonPasteShare: field(data, current, "allowAnonPasteShare"),
+    anoMaxUpload: (data.anoMaxUpload as number) || current.anoMaxUpload,
+    authMaxUpload: (data.authMaxUpload as number) || current.authMaxUpload,
+    anoIpQuota: (data.anoIpQuota as number) || current.anoIpQuota,
+    authIpQuota: (data.authIpQuota as number) || current.authIpQuota,
+    useGiBForAnon: field(data, current, "useGiBForAnon"),
+    useGiBForAuth: field(data, current, "useGiBForAuth"),
+    appName: field(data, current, "appName"),
+    appDescription: field(data, current, "appDescription"),
+    logoUrl: field(data, current, "logoUrl"),
+    faviconUrl: field(data, current, "faviconUrl"),
+    primaryColor: field(data, current, "primaryColor"),
+    primaryHover: field(data, current, "primaryHover"),
+    primaryDark: field(data, current, "primaryDark"),
+    secondaryColor: field(data, current, "secondaryColor"),
+    secondaryHover: field(data, current, "secondaryHover"),
+    secondaryDark: field(data, current, "secondaryDark"),
+    backgroundColor: field(data, current, "backgroundColor"),
+    backgroundImageUrl: field(data, current, "backgroundImageUrl"),
+    surfaceColor: field(data, current, "surfaceColor"),
+    textColor: field(data, current, "textColor"),
+    textMuted: field(data, current, "textMuted"),
+    borderColor: field(data, current, "borderColor"),
+    fontFamily: field(data, current, "fontFamily"),
+    termsOfUses: field(data, current, "termsOfUses"),
+    captchaEnabled: field(data, current, "captchaEnabled"),
+    captchaProvider: field(data, current, "captchaProvider"),
+    captchaSiteKey: field(data, current, "captchaSiteKey"),
+    captchaSecretKey: maskedSecret(data, current, "captchaSecretKey"),
+    smtpEnabled: field(data, current, "smtpEnabled"),
+    smtpHost: nullableString(data, current, "smtpHost"),
+    smtpPort: field(data, current, "smtpPort"),
+    smtpUser: nullableString(data, current, "smtpUser"),
+    smtpPassword: maskedSecret(data, current, "smtpPassword"),
+    smtpFrom: nullableString(data, current, "smtpFrom"),
+    smtpSecure: field(data, current, "smtpSecure"),
+    emailVerificationRequired: field(data, current, "emailVerificationRequired"),
+    allowIframeEmbedding: field(data, current, "allowIframeEmbedding"),
+    s3Enabled: field(data, current, "s3Enabled"),
+    s3Endpoint: nullableString(data, current, "s3Endpoint"),
+    s3Region: nullableString(data, current, "s3Region"),
+    s3Bucket: nullableString(data, current, "s3Bucket"),
+    s3AccessKeyId: nullableString(data, current, "s3AccessKeyId"),
+    s3SecretAccessKey: maskedSecret(data, current, "s3SecretAccessKey"),
+  };
+}
 
 export async function GET(request: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -200,101 +284,7 @@ Thank you for using SnowShare!`,
     } else {
       settings = await prisma.settings.update({
         where: { id: settings.id },
-        data: {
-          allowSignin: data.allowSignin !== undefined ? data.allowSignin : settings.allowSignin,
-          disableCredentialsLogin:
-            data.disableCredentialsLogin !== undefined
-              ? data.disableCredentialsLogin
-              : settings.disableCredentialsLogin,
-          allowAnonFileShare:
-            data.allowAnonFileShare !== undefined
-              ? data.allowAnonFileShare
-              : settings.allowAnonFileShare,
-          allowAnonLinkShare:
-            data.allowAnonLinkShare !== undefined
-              ? data.allowAnonLinkShare
-              : settings.allowAnonLinkShare,
-          allowAnonPasteShare:
-            data.allowAnonPasteShare !== undefined
-              ? data.allowAnonPasteShare
-              : settings.allowAnonPasteShare,
-          anoMaxUpload: data.anoMaxUpload || settings.anoMaxUpload,
-          authMaxUpload: data.authMaxUpload || settings.authMaxUpload,
-          anoIpQuota: data.anoIpQuota || settings.anoIpQuota,
-          authIpQuota: data.authIpQuota || settings.authIpQuota,
-          useGiBForAnon:
-            data.useGiBForAnon !== undefined ? data.useGiBForAnon : settings.useGiBForAnon,
-          useGiBForAuth:
-            data.useGiBForAuth !== undefined ? data.useGiBForAuth : settings.useGiBForAuth,
-          appName: data.appName !== undefined ? data.appName : settings.appName,
-          appDescription:
-            data.appDescription !== undefined ? data.appDescription : settings.appDescription,
-          logoUrl: data.logoUrl !== undefined ? data.logoUrl : settings.logoUrl,
-          faviconUrl: data.faviconUrl !== undefined ? data.faviconUrl : settings.faviconUrl,
-          primaryColor: data.primaryColor !== undefined ? data.primaryColor : settings.primaryColor,
-          primaryHover: data.primaryHover !== undefined ? data.primaryHover : settings.primaryHover,
-          primaryDark: data.primaryDark !== undefined ? data.primaryDark : settings.primaryDark,
-          secondaryColor:
-            data.secondaryColor !== undefined ? data.secondaryColor : settings.secondaryColor,
-          secondaryHover:
-            data.secondaryHover !== undefined ? data.secondaryHover : settings.secondaryHover,
-          secondaryDark:
-            data.secondaryDark !== undefined ? data.secondaryDark : settings.secondaryDark,
-          backgroundColor:
-            data.backgroundColor !== undefined ? data.backgroundColor : settings.backgroundColor,
-          backgroundImageUrl:
-            data.backgroundImageUrl !== undefined
-              ? data.backgroundImageUrl
-              : settings.backgroundImageUrl,
-          surfaceColor: data.surfaceColor !== undefined ? data.surfaceColor : settings.surfaceColor,
-          textColor: data.textColor !== undefined ? data.textColor : settings.textColor,
-          textMuted: data.textMuted !== undefined ? data.textMuted : settings.textMuted,
-          borderColor: data.borderColor !== undefined ? data.borderColor : settings.borderColor,
-          fontFamily: data.fontFamily !== undefined ? data.fontFamily : settings.fontFamily,
-          termsOfUses: data.termsOfUses !== undefined ? data.termsOfUses : settings.termsOfUses,
-          // CAPTCHA
-          captchaEnabled:
-            data.captchaEnabled !== undefined ? data.captchaEnabled : settings.captchaEnabled,
-          captchaProvider:
-            data.captchaProvider !== undefined ? data.captchaProvider : settings.captchaProvider,
-          captchaSiteKey:
-            data.captchaSiteKey !== undefined ? data.captchaSiteKey : settings.captchaSiteKey,
-          // Only update secret if a real value is provided (not the masked placeholder)
-          captchaSecretKey:
-            data.captchaSecretKey !== undefined && data.captchaSecretKey !== "••••••••"
-              ? data.captchaSecretKey || null
-              : settings.captchaSecretKey,
-          // SMTP
-          smtpEnabled: data.smtpEnabled !== undefined ? data.smtpEnabled : settings.smtpEnabled,
-          smtpHost: data.smtpHost !== undefined ? data.smtpHost || null : settings.smtpHost,
-          smtpPort: data.smtpPort !== undefined ? data.smtpPort : settings.smtpPort,
-          smtpUser: data.smtpUser !== undefined ? data.smtpUser || null : settings.smtpUser,
-          smtpPassword:
-            data.smtpPassword !== undefined && data.smtpPassword !== "••••••••"
-              ? data.smtpPassword || null
-              : settings.smtpPassword,
-          smtpFrom: data.smtpFrom !== undefined ? data.smtpFrom || null : settings.smtpFrom,
-          smtpSecure: data.smtpSecure !== undefined ? data.smtpSecure : settings.smtpSecure,
-          emailVerificationRequired:
-            data.emailVerificationRequired !== undefined
-              ? data.emailVerificationRequired
-              : settings.emailVerificationRequired,
-          allowIframeEmbedding:
-            data.allowIframeEmbedding !== undefined
-              ? data.allowIframeEmbedding
-              : settings.allowIframeEmbedding,
-          // S3 Storage
-          s3Enabled: data.s3Enabled !== undefined ? data.s3Enabled : settings.s3Enabled,
-          s3Endpoint: data.s3Endpoint !== undefined ? data.s3Endpoint || null : settings.s3Endpoint,
-          s3Region: data.s3Region !== undefined ? data.s3Region || null : settings.s3Region,
-          s3Bucket: data.s3Bucket !== undefined ? data.s3Bucket || null : settings.s3Bucket,
-          s3AccessKeyId:
-            data.s3AccessKeyId !== undefined ? data.s3AccessKeyId || null : settings.s3AccessKeyId,
-          s3SecretAccessKey:
-            data.s3SecretAccessKey !== undefined && data.s3SecretAccessKey !== "••••••••"
-              ? data.s3SecretAccessKey || null
-              : settings.s3SecretAccessKey,
-        },
+        data: buildSettingsUpdateData(data, settings),
       });
     }
 

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -35,6 +35,78 @@ function maskedSecret<K extends keyof Settings>(
   return current[key];
 }
 
+const DEFAULT_TERMS = `# Terms of Use
+
+Welcome to SnowShare! By using our platform, you agree to the following terms and conditions. Please read them carefully.
+
+## 1. Acceptance of Terms
+By accessing or using SnowShare, you agree to be bound by these Terms of Use and our Privacy Policy. If you do not agree, please do not use our platform.
+
+## 2. Description of Service
+SnowShare is a secure file, link, and paste sharing platform. We provide users with the ability to share content with expiration dates, user authentication, and quotas.
+
+## 3. User Responsibilities
+- You are responsible for maintaining the confidentiality of your account credentials.
+- You agree not to use SnowShare for any illegal or unauthorized purposes.
+- You must comply with all applicable laws and regulations.
+
+## 4. Content Restrictions
+- Do not upload or share content that is illegal, harmful, or violates the rights of others.
+- We reserve the right to remove any content that violates these terms.
+
+## 5. Privacy
+Your use of SnowShare is subject to our Privacy Policy, which explains how we collect, use, and protect your information.
+
+## 6. Limitation of Liability
+SnowShare is provided "as is" without any warranties. We are not liable for any damages arising from your use of the platform.
+
+## 7. Changes to Terms
+We reserve the right to update these Terms of Use at any time. Changes will be effective upon posting.
+
+## 8. Contact Us
+If you have any questions about these Terms of Use, please contact us at support@snowshare.com.
+
+Thank you for using SnowShare!`;
+
+function d<T>(val: unknown, fallback: T): T {
+  return val !== undefined ? (val as T) : fallback;
+}
+
+function buildFirstRunSettingsCreate(data: SettingsInput) {
+  return {
+    allowSignin: d(data.allowSignin, true),
+    disableCredentialsLogin: d(data.disableCredentialsLogin, false),
+    allowAnonFileShare: d(data.allowAnonFileShare, true),
+    allowAnonLinkShare: d(data.allowAnonLinkShare, true),
+    allowAnonPasteShare: d(data.allowAnonPasteShare, true),
+    anoMaxUpload: (data.anoMaxUpload as number) || 2048,
+    authMaxUpload: (data.authMaxUpload as number) || 51200,
+    anoIpQuota: (data.anoIpQuota as number) || 4096,
+    authIpQuota: (data.authIpQuota as number) || 102400,
+    useGiBForAnon: d(data.useGiBForAnon, false),
+    useGiBForAuth: d(data.useGiBForAuth, false),
+    appName: (data.appName as string) || "SnowShare",
+    appDescription: (data.appDescription as string) || "Share your files, pastes and URLs securely",
+    logoUrl: (data.logoUrl as string) || null,
+    faviconUrl: (data.faviconUrl as string) || null,
+    primaryColor: (data.primaryColor as string) || "#3B82F6",
+    primaryHover: (data.primaryHover as string) || "#2563EB",
+    primaryDark: (data.primaryDark as string) || "#1E40AF",
+    secondaryColor: (data.secondaryColor as string) || "#8B5CF6",
+    secondaryHover: (data.secondaryHover as string) || "#7C3AED",
+    secondaryDark: (data.secondaryDark as string) || "#6D28D9",
+    backgroundColor: (data.backgroundColor as string) || "#111827",
+    backgroundImageUrl: (data.backgroundImageUrl as string) || null,
+    surfaceColor: (data.surfaceColor as string) || "#1F2937",
+    textColor: (data.textColor as string) || "#F9FAFB",
+    textMuted: (data.textMuted as string) || "#D1D5DB",
+    borderColor: (data.borderColor as string) || "#374151",
+    fontFamily: (data.fontFamily as string) || "Geist",
+    allowIframeEmbedding: d(data.allowIframeEmbedding, false),
+    termsOfUses: (data.termsOfUses as string) || DEFAULT_TERMS,
+  };
+}
+
 function buildSettingsUpdateData(data: SettingsInput, current: Settings) {
   return {
     allowSignin: field(data, current, "allowSignin"),
@@ -111,55 +183,8 @@ export async function GET(request: NextRequest) {
       where: { enabled: true },
     });
 
-    // Create default settings if not exist
     if (!settings) {
-      settings = await prisma.settings.create({
-        data: {
-          allowSignin: true,
-          disableCredentialsLogin: false,
-          allowAnonFileShare: true,
-          allowAnonLinkShare: true,
-          allowAnonPasteShare: true,
-          anoMaxUpload: 2048,
-          authMaxUpload: 51200,
-          anoIpQuota: 4096,
-          authIpQuota: 102400,
-          useGiBForAnon: false,
-          useGiBForAuth: false,
-          termsOfUses: `# Terms of Use
-
-Welcome to SnowShare! By using our platform, you agree to the following terms and conditions. Please read them carefully.
-
-## 1. Acceptance of Terms
-By accessing or using SnowShare, you agree to be bound by these Terms of Use and our Privacy Policy. If you do not agree, please do not use our platform.
-
-## 2. Description of Service
-SnowShare is a secure file, link, and paste sharing platform. We provide users with the ability to share content with expiration dates, user authentication, and quotas.
-
-## 3. User Responsibilities
-- You are responsible for maintaining the confidentiality of your account credentials.
-- You agree not to use SnowShare for any illegal or unauthorized purposes.
-- You must comply with all applicable laws and regulations.
-
-## 4. Content Restrictions
-- Do not upload or share content that is illegal, harmful, or violates the rights of others.
-- We reserve the right to remove any content that violates these terms.
-
-## 5. Privacy
-Your use of SnowShare is subject to our Privacy Policy, which explains how we collect, use, and protect your information.
-
-## 6. Limitation of Liability
-SnowShare is provided "as is" without any warranties. We are not liable for any damages arising from your use of the platform.
-
-## 7. Changes to Terms
-We reserve the right to update these Terms of Use at any time. Changes will be effective upon posting.
-
-## 8. Contact Us
-If you have any questions about these Terms of Use, please contact us at support@snowshare.com.
-
-Thank you for using SnowShare!`,
-        },
-      });
+      settings = await prisma.settings.create({ data: buildFirstRunSettingsCreate({}) });
     }
 
     // Never expose secret keys to the client
@@ -209,78 +234,7 @@ export async function PATCH(request: NextRequest) {
     let settings = await prisma.settings.findFirst();
 
     if (!settings) {
-      settings = await prisma.settings.create({
-        data: {
-          allowSignin: data.allowSignin !== undefined ? data.allowSignin : true,
-          disableCredentialsLogin:
-            data.disableCredentialsLogin !== undefined ? data.disableCredentialsLogin : false,
-          allowAnonFileShare:
-            data.allowAnonFileShare !== undefined ? data.allowAnonFileShare : true,
-          allowAnonLinkShare:
-            data.allowAnonLinkShare !== undefined ? data.allowAnonLinkShare : true,
-          allowAnonPasteShare:
-            data.allowAnonPasteShare !== undefined ? data.allowAnonPasteShare : true,
-          anoMaxUpload: data.anoMaxUpload || 2048,
-          authMaxUpload: data.authMaxUpload || 51200,
-          anoIpQuota: data.anoIpQuota || 4096,
-          authIpQuota: data.authIpQuota || 102400,
-          useGiBForAnon: data.useGiBForAnon !== undefined ? data.useGiBForAnon : false,
-          useGiBForAuth: data.useGiBForAuth !== undefined ? data.useGiBForAuth : false,
-          appName: data.appName || "SnowShare",
-          appDescription: data.appDescription || "Share your files, pastes and URLs securely",
-          logoUrl: data.logoUrl || null,
-          faviconUrl: data.faviconUrl || null,
-          primaryColor: data.primaryColor || "#3B82F6",
-          primaryHover: data.primaryHover || "#2563EB",
-          primaryDark: data.primaryDark || "#1E40AF",
-          secondaryColor: data.secondaryColor || "#8B5CF6",
-          secondaryHover: data.secondaryHover || "#7C3AED",
-          secondaryDark: data.secondaryDark || "#6D28D9",
-          backgroundColor: data.backgroundColor || "#111827",
-          backgroundImageUrl: data.backgroundImageUrl || null,
-          surfaceColor: data.surfaceColor || "#1F2937",
-          textColor: data.textColor || "#F9FAFB",
-          textMuted: data.textMuted || "#D1D5DB",
-          borderColor: data.borderColor || "#374151",
-          fontFamily: data.fontFamily || "Geist",
-          allowIframeEmbedding:
-            data.allowIframeEmbedding !== undefined ? data.allowIframeEmbedding : false,
-          termsOfUses:
-            data.termsOfUses ||
-            `# Terms of Use
-
-Welcome to SnowShare! By using our platform, you agree to the following terms and conditions. Please read them carefully.
-
-## 1. Acceptance of Terms
-By accessing or using SnowShare, you agree to be bound by these Terms of Use and our Privacy Policy. If you do not agree, please do not use our platform.
-
-## 2. Description of Service
-SnowShare is a secure file, link, and paste sharing platform. We provide users with the ability to share content with expiration dates, user authentication, and quotas.
-
-## 3. User Responsibilities
-- You are responsible for maintaining the confidentiality of your account credentials.
-- You agree not to use SnowShare for any illegal or unauthorized purposes.
-- You must comply with all applicable laws and regulations.
-
-## 4. Content Restrictions
-- Do not upload or share content that is illegal, harmful, or violates the rights of others.
-- We reserve the right to remove any content that violates these terms.
-
-## 5. Privacy
-Your use of SnowShare is subject to our Privacy Policy, which explains how we collect, use, and protect your information.
-
-## 6. Limitation of Liability
-SnowShare is provided "as is" without any warranties. We are not liable for any damages arising from your use of the platform.
-
-## 7. Changes to Terms
-We reserve the right to update these Terms of Use at any time. Changes will be effective upon posting.
-
-## 8. Contact Us
-If you have any questions about these Terms of Use, please contact us at support@snowshare.com.
-
-Thank you for using SnowShare!`,
-        },
-      });
+      settings = await prisma.settings.create({ data: buildFirstRunSettingsCreate(data) });
     } else {
       settings = await prisma.settings.update({
         where: { id: settings.id },

--- a/src/app/api/admin/settings/route.ts
+++ b/src/app/api/admin/settings/route.ts
@@ -78,12 +78,13 @@ Thank you for using SnowShare!`,
       });
     }
 
-    // Never expose CAPTCHA secret key or SMTP password to the client
+    // Never expose secret keys to the client
     const safeSettings = {
       ...settings,
       captchaSecretKey: settings.captchaSecretKey ? "••••••••" : null,
       smtpPassword: settings.smtpPassword ? "••••••••" : null,
       allowIframeEmbedding: settings.allowIframeEmbedding,
+      s3SecretAccessKey: settings.s3SecretAccessKey ? "••••••••" : null,
     };
 
     return NextResponse.json({ settings: safeSettings, hasActiveSSO: activeProvidersCount > 0 });
@@ -282,6 +283,17 @@ Thank you for using SnowShare!`,
             data.allowIframeEmbedding !== undefined
               ? data.allowIframeEmbedding
               : settings.allowIframeEmbedding,
+          // S3 Storage
+          s3Enabled: data.s3Enabled !== undefined ? data.s3Enabled : settings.s3Enabled,
+          s3Endpoint: data.s3Endpoint !== undefined ? data.s3Endpoint || null : settings.s3Endpoint,
+          s3Region: data.s3Region !== undefined ? data.s3Region || null : settings.s3Region,
+          s3Bucket: data.s3Bucket !== undefined ? data.s3Bucket || null : settings.s3Bucket,
+          s3AccessKeyId:
+            data.s3AccessKeyId !== undefined ? data.s3AccessKeyId || null : settings.s3AccessKeyId,
+          s3SecretAccessKey:
+            data.s3SecretAccessKey !== undefined && data.s3SecretAccessKey !== "••••••••"
+              ? data.s3SecretAccessKey || null
+              : settings.s3SecretAccessKey,
         },
       });
     }
@@ -290,6 +302,7 @@ Thank you for using SnowShare!`,
       ...settings,
       captchaSecretKey: settings.captchaSecretKey ? "••••••••" : null,
       smtpPassword: settings.smtpPassword ? "••••••••" : null,
+      s3SecretAccessKey: settings.s3SecretAccessKey ? "••••••••" : null,
     };
 
     return NextResponse.json({ settings: safeUpdated });

--- a/src/app/api/admin/settings/test-s3/route.ts
+++ b/src/app/api/admin/settings/test-s3/route.ts
@@ -11,6 +11,43 @@ import { apiError, ErrorCode } from "@/lib/api-errors";
 // 404 = bucket not found (server reached), 301/400 = various redirect/config issues — all mean connectivity works.
 const REACHABLE_STATUS_CODES = new Set([200, 301, 400, 403, 404]);
 
+async function resolveS3TestSecret(fromBody: string | undefined): Promise<string | undefined> {
+  if (fromBody) return fromBody;
+  const settings = await prisma.settings.findFirst({ select: { s3SecretAccessKey: true } });
+  return settings?.s3SecretAccessKey ?? undefined;
+}
+
+function buildS3TestClient(
+  region: string,
+  endpoint: string | undefined,
+  accessKeyId: string | undefined,
+  secretAccessKey: string | undefined
+): S3Client {
+  return new S3Client({
+    region,
+    ...(endpoint && { endpoint }),
+    ...(accessKeyId && secretAccessKey && { credentials: { accessKeyId, secretAccessKey } }),
+    forcePathStyle: !!endpoint,
+  });
+}
+
+async function testS3Connectivity(
+  s3: S3Client,
+  bucket: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return { success: true };
+  } catch (err) {
+    if (err instanceof S3ServiceException) {
+      const status = err.$metadata?.httpStatusCode;
+      if (status && REACHABLE_STATUS_CODES.has(status)) return { success: true };
+      return { success: false, error: err.message };
+    }
+    throw err;
+  }
+}
+
 export async function POST(request: NextRequest) {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return apiError(request, ErrorCode.UNAUTHORIZED);
@@ -24,7 +61,7 @@ export async function POST(request: NextRequest) {
     const region: string = body.s3Region || "us-east-1";
     const endpoint: string | undefined = body.s3Endpoint || undefined;
     const accessKeyId: string | undefined = body.s3AccessKeyId || undefined;
-    const secretAccessKey: string | undefined =
+    const secretFromBody: string | undefined =
       body.s3SecretAccessKey && body.s3SecretAccessKey !== "••••••••"
         ? body.s3SecretAccessKey
         : undefined;
@@ -36,37 +73,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // If secret is masked, fall back to the stored value
-    let resolvedSecret = secretAccessKey;
-    if (!resolvedSecret) {
-      const settings = await prisma.settings.findFirst({ select: { s3SecretAccessKey: true } });
-      resolvedSecret = settings?.s3SecretAccessKey ?? undefined;
-    }
-
-    const s3 = new S3Client({
-      region,
-      ...(endpoint && { endpoint }),
-      ...(accessKeyId &&
-        resolvedSecret && {
-          credentials: { accessKeyId, secretAccessKey: resolvedSecret },
-        }),
-      forcePathStyle: !!endpoint,
-    });
-
-    try {
-      await s3.send(new HeadBucketCommand({ Bucket: bucket }));
-      return NextResponse.json({ success: true });
-    } catch (err) {
-      if (err instanceof S3ServiceException) {
-        const status = err.$metadata?.httpStatusCode;
-        // Any HTTP response from S3 means the endpoint is reachable
-        if (status && REACHABLE_STATUS_CODES.has(status)) {
-          return NextResponse.json({ success: true });
-        }
-        return NextResponse.json({ success: false, error: err.message });
-      }
-      throw err;
-    }
+    const resolvedSecret = await resolveS3TestSecret(secretFromBody);
+    const s3 = buildS3TestClient(region, endpoint, accessKeyId, resolvedSecret);
+    const result = await testS3Connectivity(s3, bucket);
+    return NextResponse.json(result);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Connection failed";
     console.error("S3 test error:", error);

--- a/src/app/api/admin/settings/test-s3/route.ts
+++ b/src/app/api/admin/settings/test-s3/route.ts
@@ -1,0 +1,75 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+import { S3Client, HeadBucketCommand } from "@aws-sdk/client-s3";
+import { S3ServiceException } from "@aws-sdk/client-s3";
+import { apiError, ErrorCode } from "@/lib/api-errors";
+
+// HTTP status codes that prove the S3 server is reachable and understands the request.
+// 200 = bucket accessible, 301 = wrong region (bucket exists), 403 = auth/ACL issue (server reached),
+// 404 = bucket not found (server reached), 301/400 = various redirect/config issues — all mean connectivity works.
+const REACHABLE_STATUS_CODES = new Set([200, 301, 400, 403, 404]);
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) return apiError(request, ErrorCode.UNAUTHORIZED);
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  if (!user?.isAdmin) return apiError(request, ErrorCode.ADMIN_ONLY);
+
+  try {
+    const body = await request.json();
+    const bucket: string | undefined = body.s3Bucket || undefined;
+    const region: string = body.s3Region || "us-east-1";
+    const endpoint: string | undefined = body.s3Endpoint || undefined;
+    const accessKeyId: string | undefined = body.s3AccessKeyId || undefined;
+    const secretAccessKey: string | undefined =
+      body.s3SecretAccessKey && body.s3SecretAccessKey !== "••••••••"
+        ? body.s3SecretAccessKey
+        : undefined;
+
+    if (!bucket) {
+      return NextResponse.json(
+        { success: false, error: "Bucket name is required" },
+        { status: 400 }
+      );
+    }
+
+    // If secret is masked, fall back to the stored value
+    let resolvedSecret = secretAccessKey;
+    if (!resolvedSecret) {
+      const settings = await prisma.settings.findFirst({ select: { s3SecretAccessKey: true } });
+      resolvedSecret = settings?.s3SecretAccessKey ?? undefined;
+    }
+
+    const s3 = new S3Client({
+      region,
+      ...(endpoint && { endpoint }),
+      ...(accessKeyId &&
+        resolvedSecret && {
+          credentials: { accessKeyId, secretAccessKey: resolvedSecret },
+        }),
+      forcePathStyle: !!endpoint,
+    });
+
+    try {
+      await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+      return NextResponse.json({ success: true });
+    } catch (err) {
+      if (err instanceof S3ServiceException) {
+        const status = err.$metadata?.httpStatusCode;
+        // Any HTTP response from S3 means the endpoint is reachable
+        if (status && REACHABLE_STATUS_CODES.has(status)) {
+          return NextResponse.json({ success: true });
+        }
+        return NextResponse.json({ success: false, error: err.message });
+      }
+      throw err;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Connection failed";
+    console.error("S3 test error:", error);
+    return NextResponse.json({ success: false, error: message });
+  }
+}

--- a/src/app/api/download/[slug]/route.ts
+++ b/src/app/api/download/[slug]/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFileShare } from "@/app/api/shares/(fileShare)/fileshare";
-import { createReadStream, existsSync } from "fs";
-import { stat } from "fs/promises";
-import path from "path";
+import { getStorageReadStream, getStorageFileSize } from "@/lib/storage";
 import { nodeStreamToWebStream, parseRangeHeader } from "@/lib/stream-utils";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { getMimeType, isSafeForInline, sanitizeFilenameForHeader } from "@/lib/mime-types";
+import path from "path";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
@@ -15,7 +14,6 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   try {
-    // Get password from query params if provided
     const url = new URL(request.url);
     const password = url.searchParams.get("password") || undefined;
 
@@ -25,24 +23,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return apiError(request, result.errorCode);
     }
 
-    const { filePath: fullPath, originalFilename } = result;
+    const { storageKey, originalFilename } = result;
 
-    if (!fullPath || !existsSync(fullPath)) {
+    if (!storageKey) {
       return apiError(request, ErrorCode.RESOURCE_NOT_FOUND);
     }
 
-    // Get file stats for size
-    const stats = await stat(fullPath);
-    const fileSize = stats.size;
-
-    // Determine content type
-    const ext = path.extname(fullPath).toLowerCase();
+    const fileSize = await getStorageFileSize(storageKey);
+    const ext = path.extname(storageKey).toLowerCase();
     const contentType = getMimeType(ext);
-
-    // Sanitize filename for Content-Disposition header to prevent header injection
     const safeFilename = sanitizeFilenameForHeader(originalFilename || "download");
 
-    // Handle range request for resumable downloads
     const range = request.headers.get("range");
 
     if (range) {
@@ -57,7 +48,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
       const { start, end } = rangeResult;
       const chunksize = end - start + 1;
-      const fileStream = createReadStream(fullPath, { start, end });
+      const fileStream = await getStorageReadStream(storageKey, { start, end });
       const webStream = nodeStreamToWebStream(fileStream);
 
       const headers = new Headers();
@@ -76,26 +67,24 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       });
     }
 
-    // Full file download using streaming
-    const fileStream = createReadStream(fullPath);
+    const fileStream = await getStorageReadStream(storageKey);
     const webStream = nodeStreamToWebStream(fileStream);
 
-    // Set appropriate headers
     const headers = new Headers();
     headers.set("Content-Length", fileSize.toString());
     headers.set("Content-Type", contentType);
-    headers.set("Content-Disposition", `attachment; filename="${safeFilename}"`);
     headers.set("Accept-Ranges", "bytes");
     headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
     headers.set("Pragma", "no-cache");
     headers.set("Expires", "0");
 
-    // Allow inline viewing only for safe types (excludes SVG/HTML to prevent XSS)
     if (isSafeForInline(contentType)) {
       const disposition = request.headers.get("accept")?.includes("text/html")
         ? "inline"
         : "attachment";
       headers.set("Content-Disposition", `${disposition}; filename="${safeFilename}"`);
+    } else {
+      headers.set("Content-Disposition", `attachment; filename="${safeFilename}"`);
     }
 
     return new NextResponse(webStream as ReadableStream<Uint8Array>, {

--- a/src/app/api/shares/(fileShare)/fileshare.ts
+++ b/src/app/api/shares/(fileShare)/fileshare.ts
@@ -1,10 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcryptjs";
-
-import path from "path";
-
-import { getUploadDir } from "@/lib/constants";
-import { existsSync } from "fs";
+import { storageFileExists } from "@/lib/storage";
 import { ErrorCode } from "@/lib/api-errors";
 
 export const getFileShare = async (slug: string, password?: string) => {
@@ -47,7 +43,6 @@ export const getFileShare = async (slug: string, password?: string) => {
   }
 
   if (share.isBulk) {
-    // Fetch only the file metadata needed for listing to avoid loading heavy columns
     const files = await prisma.shareFile.findMany({
       where: { shareId: share.id },
       select: {
@@ -67,14 +62,14 @@ export const getFileShare = async (slug: string, password?: string) => {
     return { errorCode: ErrorCode.FILE_NOT_FOUND };
   }
 
-  const filePath = path.join(getUploadDir(), share.filePath);
-  if (!existsSync(filePath)) {
+  if (!(await storageFileExists(share.filePath))) {
     return { errorCode: ErrorCode.FILE_NOT_FOUND };
   }
 
   return {
     share,
-    filePath,
+    // storageKey is the relative filename used by storage.ts (local or S3)
+    storageKey: share.filePath,
     originalFilename: share.filePath.split("_").slice(1).join("_"),
   };
 };

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -355,12 +355,19 @@ export async function POST(req: NextRequest) {
 
         lookupIpGeolocation(clientIp);
 
-        // Rename temp file to final name
+        // Move temp file to final destination (local) or upload directly to S3
         const finalFileName = generateSafeFilename(originalFilename, share.id);
         const finalFilePath = path.join(uploadsDir, finalFileName);
 
-        await rename(tempFilePath, finalFilePath);
-        tempFilePath = null; // Prevent cleanup of renamed file
+        const { isS3Enabled, uploadToStorage } = await import("@/lib/storage");
+        const s3Active = await isS3Enabled();
+        if (s3Active) {
+          await uploadToStorage(tempFilePath, finalFileName);
+          unlink(tempFilePath).catch(() => {});
+        } else {
+          await rename(tempFilePath, finalFilePath);
+        }
+        tempFilePath = null; // Prevent cleanup of moved/uploaded file
 
         // Update database with final file path
         await prisma.share.update({

--- a/src/app/api/user/shares/[id]/route.ts
+++ b/src/app/api/user/shares/[id]/route.ts
@@ -12,7 +12,64 @@ import {
 } from "@/lib/constants";
 import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
 import { hashPassword } from "@/lib/security";
-import { Prisma } from "@/generated/prisma";
+import { Prisma, Share, $Enums } from "@/generated/prisma";
+
+async function buildShareUpdateData(
+  request: NextRequest,
+  share: Share,
+  data: {
+    expiresAt?: unknown;
+    password?: unknown;
+    paste?: unknown;
+    pastelanguage?: unknown;
+    urlOriginal?: unknown;
+  }
+): Promise<Prisma.ShareUpdateInput | NextResponse> {
+  const updateData: Prisma.ShareUpdateInput = {};
+
+  if (data.expiresAt !== undefined) {
+    updateData.expiresAt = data.expiresAt ? new Date(data.expiresAt as string) : null;
+  }
+
+  if (data.password !== undefined) {
+    if (data.password) {
+      const pw = data.password as string;
+      if (pw.length < PASSWORD_MIN_LENGTH || pw.length > PASSWORD_MAX_LENGTH) {
+        return apiError(request, ErrorCode.PASSWORD_INVALID_LENGTH, {
+          min: PASSWORD_MIN_LENGTH,
+          max: PASSWORD_MAX_LENGTH,
+        });
+      }
+      updateData.password = await hashPassword(pw);
+    } else {
+      updateData.password = null;
+    }
+  }
+
+  if (share.type === "PASTE" && data.paste !== undefined) {
+    if (typeof data.paste !== "string" || data.paste.length > MAX_PASTE_SIZE) {
+      return apiError(request, ErrorCode.PASTE_CONTENT_REQUIRED);
+    }
+    updateData.paste = data.paste;
+  }
+
+  if (share.type === "PASTE" && data.pastelanguage !== undefined) {
+    if (!isValidPasteLanguage(data.pastelanguage as string)) {
+      return apiError(request, ErrorCode.PASTE_LANGUAGE_INVALID);
+    }
+    updateData.pastelanguage = data.pastelanguage as $Enums.pasteType;
+  }
+
+  if (share.type === "URL" && data.urlOriginal !== undefined) {
+    const urlValidation = isValidUrl(data.urlOriginal as string);
+    if (!urlValidation.valid) {
+      return apiError(request, ErrorCode.INVALID_URL);
+    }
+    updateData.urlOriginal = data.urlOriginal as string;
+  }
+
+  return updateData;
+}
 
 // DELETE - Supprimer un partage
 export async function DELETE(
@@ -79,59 +136,12 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     }
 
     const data = await request.json();
-    const { expiresAt, password, paste, pastelanguage, urlOriginal } = data;
-
-    const updateData: Prisma.ShareUpdateInput = {};
-
-    if (expiresAt !== undefined) {
-      updateData.expiresAt = expiresAt ? new Date(expiresAt) : null;
-    }
-
-    // Hash password if provided, or set to null to remove
-    if (password !== undefined) {
-      if (password) {
-        // Validate password length
-        if (password.length < PASSWORD_MIN_LENGTH || password.length > PASSWORD_MAX_LENGTH) {
-          return apiError(request, ErrorCode.PASSWORD_INVALID_LENGTH, {
-            min: PASSWORD_MIN_LENGTH,
-            max: PASSWORD_MAX_LENGTH,
-          });
-        }
-        updateData.password = await hashPassword(password);
-      } else {
-        updateData.password = null;
-      }
-    }
-
-    // Mise à jour spécifique selon le type
-    if (share.type === "PASTE" && paste !== undefined) {
-      // Validate paste content length to prevent DoS
-      if (typeof paste !== "string" || paste.length > MAX_PASTE_SIZE) {
-        return apiError(request, ErrorCode.PASTE_CONTENT_REQUIRED);
-      }
-      updateData.paste = paste;
-    }
-
-    if (share.type === "PASTE" && pastelanguage !== undefined) {
-      // Validate pastelanguage is a valid enum value
-      if (!isValidPasteLanguage(pastelanguage)) {
-        return apiError(request, ErrorCode.PASTE_LANGUAGE_INVALID);
-      }
-      updateData.pastelanguage = pastelanguage;
-    }
-
-    if (share.type === "URL" && urlOriginal !== undefined) {
-      // Validate URL format and protocol
-      const urlValidation = isValidUrl(urlOriginal);
-      if (!urlValidation.valid) {
-        return apiError(request, ErrorCode.INVALID_URL);
-      }
-      updateData.urlOriginal = urlOriginal;
-    }
+    const updateDataOrError = await buildShareUpdateData(request, share, data);
+    if (updateDataOrError instanceof NextResponse) return updateDataOrError;
 
     const updatedShare = await prisma.share.update({
       where: { id: (await params).id },
-      data: updateData,
+      data: updateDataOrError,
     });
 
     return NextResponse.json({ share: updatedShare });

--- a/src/app/api/user/shares/[id]/route.ts
+++ b/src/app/api/user/shares/[id]/route.ts
@@ -2,8 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { unlink } from "fs/promises";
-import { join } from "path";
+import { deleteFromStorage } from "@/lib/storage";
 import {
   isValidPasteLanguage,
   isValidUrl,
@@ -39,11 +38,9 @@ export async function DELETE(
       return apiError(request, ErrorCode.FORBIDDEN);
     }
 
-    // Si c'est un fichier, le supprimer du système de fichiers
     if (share.type === "FILE" && share.filePath) {
       try {
-        const filePath = join(process.cwd(), "uploads", share.filePath);
-        await unlink(filePath);
+        await deleteFromStorage(share.filePath);
       } catch (error) {
         console.error("Error deleting file:", error);
       }

--- a/src/app/api/v1/upload/route.ts
+++ b/src/app/api/v1/upload/route.ts
@@ -110,10 +110,16 @@ export async function POST(request: NextRequest) {
     const safeFilename = generateSafeFilename(file.name, share.id);
     const finalPath = path.join(uploadsDir, safeFilename);
 
-    // Rename + DB update: clean up on failure to keep FS and DB consistent
     const { prisma } = await import("@/lib/prisma");
+    const { isS3Enabled, uploadToStorage } = await import("@/lib/storage");
+    const s3Active = await isS3Enabled();
     try {
-      await rename(tmpPath, finalPath);
+      if (s3Active) {
+        await uploadToStorage(tmpPath, safeFilename);
+        unlink(tmpPath).catch(() => {});
+      } else {
+        await rename(tmpPath, finalPath);
+      }
       await prisma.share.update({
         where: { id: share.id },
         data: { filePath: safeFilename },
@@ -122,7 +128,7 @@ export async function POST(request: NextRequest) {
       // Roll back: delete share record and temp file
       await prisma.share.delete({ where: { id: share.id } }).catch(() => {});
       unlink(tmpPath).catch(() => {});
-      unlink(finalPath).catch(() => {});
+      if (!s3Active) unlink(finalPath).catch(() => {});
       throw fsErr;
     }
 

--- a/src/components/admin/S3StorageSection.tsx
+++ b/src/components/admin/S3StorageSection.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface S3SectionSettings {
+  s3Enabled: boolean;
+  s3Endpoint: string | null;
+  s3Region: string | null;
+  s3Bucket: string | null;
+  s3AccessKeyId: string | null;
+  s3SecretAccessKey: string | null;
+}
+
+interface Props {
+  settings: S3SectionSettings;
+  onChange: (patch: Partial<S3SectionSettings>) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Local UI primitives
+// ---------------------------------------------------------------------------
+
+interface ToggleProps {
+  checked: boolean;
+  onChange: () => void;
+}
+
+function Toggle({ checked, onChange }: ToggleProps) {
+  return (
+    <button
+      onClick={onChange}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors cursor-pointer ${
+        checked ? "bg-[var(--primary)]" : "bg-gray-600"
+      }`}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-7" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+interface FieldInputProps {
+  label: string;
+  type?: "text" | "password";
+  value: string;
+  onChange: (value: string | null) => void;
+  placeholder?: string;
+  hint?: string;
+}
+
+function FieldInput({ label, type = "text", value, onChange, placeholder, hint }: FieldInputProps) {
+  return (
+    <div>
+      <label className="text-sm font-medium text-[var(--foreground)]">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value || null)}
+        placeholder={placeholder}
+        className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+      />
+      {hint && <p className="text-xs text-[var(--foreground-muted)] mt-1">{hint}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Controlled section — no own state, no save button
+// ---------------------------------------------------------------------------
+
+export default function S3StorageSection({ settings, onChange }: Props) {
+  const { t } = useTranslation();
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const res = await fetch("/api/admin/settings/test-s3", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(settings),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setTestResult({ success: true, message: t("admin.settings.s3_test_success") });
+      } else {
+        setTestResult({
+          success: false,
+          message: t("admin.settings.s3_test_error", { error: data.error }),
+        });
+      }
+    } catch {
+      setTestResult({
+        success: false,
+        message: t("admin.settings.s3_test_error", { error: "Network error" }),
+      });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-[var(--foreground)]">
+        {t("admin.settings.section_s3")}
+      </h3>
+
+      <div className="flex items-center justify-between p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+        <div>
+          <label className="text-[var(--foreground)] font-medium">
+            {t("admin.settings.s3_enabled")}
+          </label>
+          <p className="text-sm text-[var(--foreground-muted)] mt-1">
+            {t("admin.settings.s3_enabled_desc")}
+          </p>
+        </div>
+        <Toggle
+          checked={settings.s3Enabled}
+          onChange={() => onChange({ s3Enabled: !settings.s3Enabled })}
+        />
+      </div>
+
+      {settings.s3Enabled && (
+        <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <FieldInput
+              label={t("admin.settings.s3_bucket")}
+              value={settings.s3Bucket ?? ""}
+              onChange={(v) => onChange({ s3Bucket: v })}
+              placeholder="my-bucket"
+            />
+            <FieldInput
+              label={t("admin.settings.s3_region")}
+              value={settings.s3Region ?? ""}
+              onChange={(v) => onChange({ s3Region: v })}
+              placeholder="us-east-1"
+            />
+          </div>
+
+          <FieldInput
+            label={t("admin.settings.s3_endpoint")}
+            value={settings.s3Endpoint ?? ""}
+            onChange={(v) => onChange({ s3Endpoint: v })}
+            placeholder="https://s3.example.com"
+            hint={t("admin.settings.s3_endpoint_hint") as string}
+          />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <FieldInput
+              label={t("admin.settings.s3_access_key_id")}
+              value={settings.s3AccessKeyId ?? ""}
+              onChange={(v) => onChange({ s3AccessKeyId: v })}
+              placeholder="AKIAIOSFODNN7EXAMPLE"
+            />
+            <FieldInput
+              label={t("admin.settings.s3_secret_access_key")}
+              type="password"
+              value={settings.s3SecretAccessKey ?? ""}
+              onChange={(v) => onChange({ s3SecretAccessKey: v })}
+              placeholder={t("admin.settings.s3_secret_access_key_placeholder") as string}
+            />
+          </div>
+
+          <div className="p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+            <p className="text-xs text-yellow-400">{t("admin.settings.s3_env_priority")}</p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-1">
+            <button
+              onClick={handleTest}
+              disabled={testing || !settings.s3Bucket}
+              className="px-4 py-2 rounded-lg font-medium text-sm transition-all disabled:opacity-50 border border-[var(--border)] text-[var(--foreground)] hover:bg-[var(--surface)]"
+            >
+              {testing ? t("admin.settings.s3_testing") : t("admin.settings.s3_test")}
+            </button>
+
+            {testResult && (
+              <span
+                className={`text-sm font-medium ${testResult.success ? "text-green-400" : "text-red-400"}`}
+              >
+                {testResult.message}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/SettingsTab.tsx
+++ b/src/components/admin/SettingsTab.tsx
@@ -8,6 +8,7 @@ import MDEditor from "@uiw/react-md-editor";
 import { Snackbar, Alert } from "@mui/material";
 import { convertFromMB, convertToMB } from "@/lib/formatSize";
 import WarningModal from "./WarningModal";
+import S3StorageSection from "./S3StorageSection";
 
 interface Settings {
   id: number;
@@ -38,6 +39,13 @@ interface Settings {
   smtpFrom: string | null;
   smtpSecure: boolean;
   emailVerificationRequired: boolean;
+  // S3 Storage
+  s3Enabled: boolean;
+  s3Endpoint: string | null;
+  s3Region: string | null;
+  s3Bucket: string | null;
+  s3AccessKeyId: string | null;
+  s3SecretAccessKey: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +205,12 @@ export default function SettingsTab() {
         smtpFrom: data.settings.smtpFrom ?? null,
         smtpSecure: data.settings.smtpSecure ?? false,
         emailVerificationRequired: data.settings.emailVerificationRequired ?? false,
+        s3Enabled: data.settings.s3Enabled ?? false,
+        s3Endpoint: data.settings.s3Endpoint ?? null,
+        s3Region: data.settings.s3Region ?? null,
+        s3Bucket: data.settings.s3Bucket ?? null,
+        s3AccessKeyId: data.settings.s3AccessKeyId ?? null,
+        s3SecretAccessKey: data.settings.s3SecretAccessKey ?? null,
       });
     } catch (err) {
       setToastMessage(t("admin.error_load_data"));
@@ -787,6 +801,13 @@ export default function SettingsTab() {
               </div>
             )}
           </div>
+
+          {/* S3 Storage */}
+          {/* TODO: refactor other sections (General, CAPTCHA, SMTP, Quotas) into controlled components following the same pattern as S3StorageSection */}
+          <S3StorageSection
+            settings={settings}
+            onChange={(patch) => setSettings((prev) => (prev ? { ...prev, ...patch } : prev))}
+          />
 
           {/* Save Button */}
           <div className="flex justify-end">

--- a/src/components/admin/SettingsTab.tsx
+++ b/src/components/admin/SettingsTab.tsx
@@ -803,7 +803,7 @@ export default function SettingsTab() {
           </div>
 
           {/* S3 Storage */}
-          {/* TODO: refactor other sections (General, CAPTCHA, SMTP, Quotas) into controlled components following the same pattern as S3StorageSection */}
+          {/* See issue #261: refactor General/CAPTCHA/SMTP/Quotas sections into controlled components */}
           <S3StorageSection
             settings={settings}
             onChange={(patch) => setSettings((prev) => (prev ? { ...prev, ...patch } : prev))}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -499,7 +499,22 @@
       "smtp_secure": "SSL/TLS verwenden",
       "smtp_secure_hint": "Für Port 465 aktivieren, für Port 587 (STARTTLS) deaktivieren",
       "email_verification_required": "E-Mail-Verifizierung erforderlich",
-      "email_verification_required_desc": "Neue Benutzer müssen ihre E-Mail-Adresse verifizieren, bevor sie sich anmelden können"
+      "email_verification_required_desc": "Neue Benutzer müssen ihre E-Mail-Adresse verifizieren, bevor sie sich anmelden können",
+      "section_s3": "S3-Objektspeicher",
+      "s3_enabled": "S3-Speicher aktivieren",
+      "s3_enabled_desc": "Hochgeladene Dateien in einem S3-kompatiblen Bucket statt im lokalen Dateisystem speichern",
+      "s3_bucket": "Bucket",
+      "s3_region": "Region",
+      "s3_endpoint": "Benutzerdefinierter Endpunkt",
+      "s3_endpoint_hint": "Optional. Erforderlich für MinIO oder andere S3-kompatible Dienste.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Leer lassen, um den bestehenden Schlüssel zu behalten",
+      "s3_env_priority": "Hinweis: Umgebungsvariablen (S3_BUCKET, S3_REGION, etc.) haben immer Vorrang vor diesen Einstellungen.",
+      "s3_test": "Verbindung testen",
+      "s3_testing": "Teste…",
+      "s3_test_success": "Verbindung erfolgreich.",
+      "s3_test_error": "Verbindung fehlgeschlagen: {{error}}"
     },
     "quotas": {
       "title": "Upload-Quoten",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -503,7 +503,22 @@
       "smtp_secure": "Use SSL/TLS",
       "smtp_secure_hint": "Enable for port 465, disable for port 587 (STARTTLS)",
       "email_verification_required": "Require Email Verification",
-      "email_verification_required_desc": "New users must verify their email address before signing in"
+      "email_verification_required_desc": "New users must verify their email address before signing in",
+      "section_s3": "S3 Object Storage",
+      "s3_enabled": "Enable S3 Storage",
+      "s3_enabled_desc": "Store uploaded files in an S3-compatible bucket instead of the local filesystem",
+      "s3_bucket": "Bucket",
+      "s3_region": "Region",
+      "s3_endpoint": "Custom Endpoint",
+      "s3_endpoint_hint": "Optional. Required for MinIO or other S3-compatible services.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Leave blank to keep existing key",
+      "s3_env_priority": "Note: environment variables (S3_BUCKET, S3_REGION, etc.) always take priority over these settings.",
+      "s3_test": "Test connection",
+      "s3_testing": "Testing…",
+      "s3_test_success": "Connection successful.",
+      "s3_test_error": "Connection failed: {{error}}"
     },
     "quotas": {
       "title": "Upload Quotas",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -499,7 +499,22 @@
       "smtp_secure": "Usar SSL/TLS",
       "smtp_secure_hint": "Activar para el puerto 465, desactivar para el puerto 587 (STARTTLS)",
       "email_verification_required": "Requerir verificación de email",
-      "email_verification_required_desc": "Los nuevos usuarios deben verificar su dirección de email antes de iniciar sesión"
+      "email_verification_required_desc": "Los nuevos usuarios deben verificar su dirección de email antes de iniciar sesión",
+      "section_s3": "Almacenamiento de objetos S3",
+      "s3_enabled": "Activar almacenamiento S3",
+      "s3_enabled_desc": "Almacenar los archivos subidos en un bucket compatible con S3 en lugar del sistema de archivos local",
+      "s3_bucket": "Bucket",
+      "s3_region": "Región",
+      "s3_endpoint": "Endpoint personalizado",
+      "s3_endpoint_hint": "Opcional. Necesario para MinIO u otros servicios compatibles con S3.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Dejar en blanco para conservar la clave existente",
+      "s3_env_priority": "Nota: las variables de entorno (S3_BUCKET, S3_REGION, etc.) siempre tienen prioridad sobre estos ajustes.",
+      "s3_test": "Probar conexión",
+      "s3_testing": "Probando…",
+      "s3_test_success": "Conexión exitosa.",
+      "s3_test_error": "Conexión fallida: {{error}}"
     },
     "quotas": {
       "title": "Cuotas de Carga",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -503,7 +503,22 @@
       "smtp_secure": "Utiliser SSL/TLS",
       "smtp_secure_hint": "Activer pour le port 465, désactiver pour le port 587 (STARTTLS)",
       "email_verification_required": "Exiger la vérification de l'email",
-      "email_verification_required_desc": "Les nouveaux utilisateurs doivent vérifier leur adresse email avant de se connecter"
+      "email_verification_required_desc": "Les nouveaux utilisateurs doivent vérifier leur adresse email avant de se connecter",
+      "section_s3": "Stockage objet S3",
+      "s3_enabled": "Activer le stockage S3",
+      "s3_enabled_desc": "Stocker les fichiers uploadés dans un bucket compatible S3 plutôt que sur le système de fichiers local",
+      "s3_bucket": "Bucket",
+      "s3_region": "Région",
+      "s3_endpoint": "Endpoint personnalisé",
+      "s3_endpoint_hint": "Optionnel. Requis pour MinIO ou d'autres services compatibles S3.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Laisser vide pour conserver la clé existante",
+      "s3_env_priority": "Note : les variables d'environnement (S3_BUCKET, S3_REGION, etc.) ont toujours la priorité sur ces paramètres.",
+      "s3_test": "Tester la connexion",
+      "s3_testing": "Test en cours…",
+      "s3_test_success": "Connexion réussie.",
+      "s3_test_error": "Échec de la connexion : {{error}}"
     },
     "quotas": {
       "title": "Quotas d'upload",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -507,7 +507,22 @@
       "smtp_secure": "SSL/TLS gebruiken",
       "smtp_secure_hint": "Inschakelen voor poort 465, uitschakelen voor poort 587 (STARTTLS)",
       "email_verification_required": "E-mailverificatie vereisen",
-      "email_verification_required_desc": "Nieuwe gebruikers moeten hun e-mailadres verifiëren voordat ze kunnen inloggen"
+      "email_verification_required_desc": "Nieuwe gebruikers moeten hun e-mailadres verifiëren voordat ze kunnen inloggen",
+      "section_s3": "S3-objectopslag",
+      "s3_enabled": "S3-opslag inschakelen",
+      "s3_enabled_desc": "Geüploade bestanden opslaan in een S3-compatibele bucket in plaats van het lokale bestandssysteem",
+      "s3_bucket": "Bucket",
+      "s3_region": "Regio",
+      "s3_endpoint": "Aangepast eindpunt",
+      "s3_endpoint_hint": "Optioneel. Vereist voor MinIO of andere S3-compatibele services.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Leeg laten om de bestaande sleutel te behouden",
+      "s3_env_priority": "Opmerking: omgevingsvariabelen (S3_BUCKET, S3_REGION, etc.) hebben altijd voorrang op deze instellingen.",
+      "s3_test": "Verbinding testen",
+      "s3_testing": "Testen…",
+      "s3_test_success": "Verbinding geslaagd.",
+      "s3_test_error": "Verbinding mislukt: {{error}}"
     },
     "quotas": {
       "title": "Uploadquota",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -504,7 +504,22 @@
       "smtp_secure": "Używaj SSL/TLS",
       "smtp_secure_hint": "Włącz dla portu 465, wyłącz dla portu 587 (STARTTLS)",
       "email_verification_required": "Wymagaj weryfikacji e-mail",
-      "email_verification_required_desc": "Nowi użytkownicy muszą zweryfikować swój adres e-mail przed zalogowaniem"
+      "email_verification_required_desc": "Nowi użytkownicy muszą zweryfikować swój adres e-mail przed zalogowaniem",
+      "section_s3": "Obiektowy magazyn S3",
+      "s3_enabled": "Włącz magazyn S3",
+      "s3_enabled_desc": "Przechowuj przesłane pliki w zasobniku kompatybilnym z S3 zamiast lokalnego systemu plików",
+      "s3_bucket": "Bucket",
+      "s3_region": "Region",
+      "s3_endpoint": "Niestandardowy endpoint",
+      "s3_endpoint_hint": "Opcjonalne. Wymagane dla MinIO lub innych usług kompatybilnych z S3.",
+      "s3_access_key_id": "Access Key ID",
+      "s3_secret_access_key": "Secret Access Key",
+      "s3_secret_access_key_placeholder": "Zostaw puste, aby zachować istniejący klucz",
+      "s3_env_priority": "Uwaga: zmienne środowiskowe (S3_BUCKET, S3_REGION, itp.) zawsze mają pierwszeństwo przed tymi ustawieniami.",
+      "s3_test": "Testuj połączenie",
+      "s3_testing": "Testowanie…",
+      "s3_test_success": "Połączenie udane.",
+      "s3_test_error": "Połączenie nie powiodło się: {{error}}"
     },
     "quotas": {
       "title": "Limity przesyłania",

--- a/src/lib/bulk-upload-utils.ts
+++ b/src/lib/bulk-upload-utils.ts
@@ -7,6 +7,7 @@ import { Readable } from "stream";
 import crypto from "crypto";
 import { getUploadDir } from "./constants";
 import { getMimeType as getMimeTypeFromLib } from "./mime-types";
+import { isS3Enabled, getStorageReadStream, storageFileExists } from "./storage";
 
 export interface FileEntry {
   file: File;
@@ -85,16 +86,27 @@ export async function createZipStream(
     zlib: { level: 6 },
   });
 
-  const uploadsDir = getUploadDir();
-
-  for (const file of files) {
-    const fullPath = path.join(uploadsDir, file.filePath);
-    try {
-      await access(fullPath);
-      const displayPath = file.relativePath || file.originalName;
-      archive.file(fullPath, { name: displayPath });
-    } catch {
-      // Skip missing files
+  if (isS3Enabled()) {
+    for (const file of files) {
+      try {
+        const stream = await getStorageReadStream(file.filePath);
+        const displayPath = file.relativePath || file.originalName;
+        archive.append(stream, { name: displayPath });
+      } catch {
+        // skip missing files
+      }
+    }
+  } else {
+    const uploadsDir = getUploadDir();
+    for (const file of files) {
+      const fullPath = path.join(uploadsDir, file.filePath);
+      try {
+        await access(fullPath);
+        const displayPath = file.relativePath || file.originalName;
+        archive.file(fullPath, { name: displayPath });
+      } catch {
+        // skip missing files
+      }
     }
   }
 
@@ -113,3 +125,5 @@ export function validateFilePath(filePath: string): boolean {
 export function normalizeRelativePath(relativePath: string): string {
   return relativePath.replace(/\\/g, "/").replace(/^\/+/, "").replace(/\.\.+/g, ".");
 }
+
+export { storageFileExists };

--- a/src/lib/bulk-upload-utils.ts
+++ b/src/lib/bulk-upload-utils.ts
@@ -7,7 +7,7 @@ import { Readable } from "stream";
 import crypto from "crypto";
 import { getUploadDir } from "./constants";
 import { getMimeType as getMimeTypeFromLib } from "./mime-types";
-import { isS3Enabled, getStorageReadStream, storageFileExists } from "./storage";
+import { getStorageReadStream, storageFileExists } from "./storage";
 
 export interface FileEntry {
   file: File;
@@ -86,27 +86,13 @@ export async function createZipStream(
     zlib: { level: 6 },
   });
 
-  if (isS3Enabled()) {
-    for (const file of files) {
-      try {
-        const stream = await getStorageReadStream(file.filePath);
-        const displayPath = file.relativePath || file.originalName;
-        archive.append(stream, { name: displayPath });
-      } catch {
-        // skip missing files
-      }
-    }
-  } else {
-    const uploadsDir = getUploadDir();
-    for (const file of files) {
-      const fullPath = path.join(uploadsDir, file.filePath);
-      try {
-        await access(fullPath);
-        const displayPath = file.relativePath || file.originalName;
-        archive.file(fullPath, { name: displayPath });
-      } catch {
-        // skip missing files
-      }
+  for (const file of files) {
+    try {
+      const stream = await getStorageReadStream(file.filePath);
+      const displayPath = file.relativePath || file.originalName;
+      archive.append(stream, { name: displayPath });
+    } catch {
+      // skip missing files
     }
   }
 

--- a/src/lib/quota-shared.ts
+++ b/src/lib/quota-shared.ts
@@ -4,10 +4,7 @@
  */
 
 import { prisma } from "@/lib/prisma";
-import { stat } from "fs/promises";
-import path from "path";
-import { getUploadDir } from "@/lib/constants";
-import { isS3Enabled, getStorageFileSize } from "@/lib/storage";
+import { getStorageFileSize } from "@/lib/storage";
 
 /**
  * Calculate total upload size in bytes for an IP address.
@@ -35,12 +32,7 @@ export async function calculateIpUploadSizeBytes(ipAddress: string): Promise<num
       }
     } else if (share.filePath) {
       try {
-        if (isS3Enabled()) {
-          totalSize += await getStorageFileSize(share.filePath);
-        } else {
-          const stats = await stat(path.join(getUploadDir(), share.filePath));
-          totalSize += stats.size;
-        }
+        totalSize += await getStorageFileSize(share.filePath);
       } catch {
         // File missing — skip
       }

--- a/src/lib/quota-shared.ts
+++ b/src/lib/quota-shared.ts
@@ -7,10 +7,11 @@ import { prisma } from "@/lib/prisma";
 import { stat } from "fs/promises";
 import path from "path";
 import { getUploadDir } from "@/lib/constants";
+import { isS3Enabled, getStorageFileSize } from "@/lib/storage";
 
 /**
  * Calculate total upload size in bytes for an IP address.
- * Handles both single files (stat on disk) and bulk uploads (sizes from DB).
+ * Bulk uploads use sizes stored in DB; single-file uploads stat the local file or query S3.
  */
 export async function calculateIpUploadSizeBytes(ipAddress: string): Promise<number> {
   const shares = await prisma.share.findMany({
@@ -25,7 +26,6 @@ export async function calculateIpUploadSizeBytes(ipAddress: string): Promise<num
     },
   });
 
-  const uploadsDir = getUploadDir();
   let totalSize = 0;
 
   for (const share of shares) {
@@ -34,12 +34,15 @@ export async function calculateIpUploadSizeBytes(ipAddress: string): Promise<num
         totalSize += Number(file.size);
       }
     } else if (share.filePath) {
-      const fullPath = path.join(uploadsDir, share.filePath);
       try {
-        const stats = await stat(fullPath);
-        totalSize += stats.size;
+        if (isS3Enabled()) {
+          totalSize += await getStorageFileSize(share.filePath);
+        } else {
+          const stats = await stat(path.join(getUploadDir(), share.filePath));
+          totalSize += stats.size;
+        }
       } catch {
-        // File doesn't exist on disk, skip
+        // File missing — skip
       }
     }
   }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,113 @@
+import {
+  S3Client,
+  GetObjectCommand,
+  HeadObjectCommand,
+  DeleteObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+import { createReadStream, existsSync } from "fs";
+import { stat, unlink } from "fs/promises";
+import { Readable } from "stream";
+import path from "path";
+import { getUploadDir } from "./constants";
+
+let _s3: S3Client | null | undefined = undefined;
+
+function getS3Client(): S3Client | null {
+  if (_s3 !== undefined) return _s3;
+  if (!process.env.S3_BUCKET) {
+    _s3 = null;
+    return null;
+  }
+  _s3 = new S3Client({
+    region: process.env.S3_REGION || "us-east-1",
+    ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT }),
+    ...(process.env.S3_ACCESS_KEY_ID && {
+      credentials: {
+        accessKeyId: process.env.S3_ACCESS_KEY_ID,
+        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+      },
+    }),
+    // Required for MinIO / path-style endpoints
+    forcePathStyle: !!process.env.S3_ENDPOINT,
+  });
+  return _s3;
+}
+
+function bucket(): string {
+  return process.env.S3_BUCKET!;
+}
+
+export function isS3Enabled(): boolean {
+  return !!process.env.S3_BUCKET;
+}
+
+/** Upload a local file to S3 under the given key. No-op when S3 is disabled. */
+export async function uploadToStorage(localPath: string, key: string): Promise<void> {
+  const s3 = getS3Client();
+  if (!s3) return;
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket(),
+      Key: key,
+      Body: createReadStream(localPath),
+    })
+  );
+}
+
+/** Returns true if the file exists (locally or in S3). */
+export async function storageFileExists(key: string): Promise<boolean> {
+  const s3 = getS3Client();
+  if (!s3) return existsSync(path.join(getUploadDir(), key));
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: bucket(), Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Returns the byte size of a stored file. */
+export async function getStorageFileSize(key: string): Promise<number> {
+  const s3 = getS3Client();
+  if (!s3) {
+    const stats = await stat(path.join(getUploadDir(), key));
+    return stats.size;
+  }
+  const res = await s3.send(new HeadObjectCommand({ Bucket: bucket(), Key: key }));
+  return res.ContentLength ?? 0;
+}
+
+/** Returns a readable stream for a stored file, optionally with a byte range. */
+export async function getStorageReadStream(
+  key: string,
+  range?: { start: number; end: number }
+): Promise<Readable> {
+  const s3 = getS3Client();
+  if (!s3) {
+    return createReadStream(path.join(getUploadDir(), key), range);
+  }
+  const res = await s3.send(
+    new GetObjectCommand({
+      Bucket: bucket(),
+      Key: key,
+      ...(range && { Range: `bytes=${range.start}-${range.end}` }),
+    })
+  );
+  // In Node.js, the AWS SDK returns a Node.js Readable stream
+  return res.Body as unknown as Readable;
+}
+
+/** Deletes a file from storage (local or S3). Silently ignores missing files. */
+export async function deleteFromStorage(key: string): Promise<void> {
+  const s3 = getS3Client();
+  if (!s3) {
+    try {
+      await unlink(path.join(getUploadDir(), key));
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+    return;
+  }
+  await s3.send(new DeleteObjectCommand({ Bucket: bucket(), Key: key }));
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,45 +10,82 @@ import { stat, unlink } from "fs/promises";
 import { Readable } from "stream";
 import path from "path";
 import { getUploadDir } from "./constants";
+import { prisma } from "./prisma";
 
-let _s3: S3Client | null | undefined = undefined;
+interface S3Config {
+  bucket: string;
+  region: string;
+  endpoint?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
 
-function getS3Client(): S3Client | null {
-  if (_s3 !== undefined) return _s3;
-  if (!process.env.S3_BUCKET) {
-    _s3 = null;
+async function getS3Config(): Promise<S3Config | null> {
+  // Env vars take priority — no DB query needed
+  if (process.env.S3_BUCKET) {
+    return {
+      bucket: process.env.S3_BUCKET,
+      region: process.env.S3_REGION || "us-east-1",
+      endpoint: process.env.S3_ENDPOINT,
+      accessKeyId: process.env.S3_ACCESS_KEY_ID,
+      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+    };
+  }
+
+  // Fall back to DB settings
+  try {
+    const settings = await prisma.settings.findFirst({
+      select: {
+        s3Enabled: true,
+        s3Bucket: true,
+        s3Region: true,
+        s3Endpoint: true,
+        s3AccessKeyId: true,
+        s3SecretAccessKey: true,
+      },
+    });
+
+    if (!settings?.s3Enabled || !settings.s3Bucket) return null;
+
+    return {
+      bucket: settings.s3Bucket,
+      region: settings.s3Region || "us-east-1",
+      endpoint: settings.s3Endpoint ?? undefined,
+      accessKeyId: settings.s3AccessKeyId ?? undefined,
+      secretAccessKey: settings.s3SecretAccessKey ?? undefined,
+    };
+  } catch {
     return null;
   }
-  _s3 = new S3Client({
-    region: process.env.S3_REGION || "us-east-1",
-    ...(process.env.S3_ENDPOINT && { endpoint: process.env.S3_ENDPOINT }),
-    ...(process.env.S3_ACCESS_KEY_ID && {
-      credentials: {
-        accessKeyId: process.env.S3_ACCESS_KEY_ID,
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
-      },
-    }),
-    // Required for MinIO / path-style endpoints
-    forcePathStyle: !!process.env.S3_ENDPOINT,
+}
+
+function buildS3Client(config: S3Config): S3Client {
+  return new S3Client({
+    region: config.region,
+    ...(config.endpoint && { endpoint: config.endpoint }),
+    ...(config.accessKeyId &&
+      config.secretAccessKey && {
+        credentials: {
+          accessKeyId: config.accessKeyId,
+          secretAccessKey: config.secretAccessKey,
+        },
+      }),
+    forcePathStyle: !!config.endpoint,
   });
-  return _s3;
 }
 
-function bucket(): string {
-  return process.env.S3_BUCKET!;
-}
-
-export function isS3Enabled(): boolean {
-  return !!process.env.S3_BUCKET;
+export async function isS3Enabled(): Promise<boolean> {
+  return (await getS3Config()) !== null;
 }
 
 /** Upload a local file to S3 under the given key. No-op when S3 is disabled. */
 export async function uploadToStorage(localPath: string, key: string): Promise<void> {
-  const s3 = getS3Client();
-  if (!s3) return;
+  const config = await getS3Config();
+  if (!config) return;
+  const s3 = buildS3Client(config);
   await s3.send(
     new PutObjectCommand({
-      Bucket: bucket(),
+      Bucket: config.bucket,
       Key: key,
       Body: createReadStream(localPath),
     })
@@ -57,10 +94,11 @@ export async function uploadToStorage(localPath: string, key: string): Promise<v
 
 /** Returns true if the file exists (locally or in S3). */
 export async function storageFileExists(key: string): Promise<boolean> {
-  const s3 = getS3Client();
-  if (!s3) return existsSync(path.join(getUploadDir(), key));
+  const config = await getS3Config();
+  if (!config) return existsSync(path.join(getUploadDir(), key));
   try {
-    await s3.send(new HeadObjectCommand({ Bucket: bucket(), Key: key }));
+    const s3 = buildS3Client(config);
+    await s3.send(new HeadObjectCommand({ Bucket: config.bucket, Key: key }));
     return true;
   } catch {
     return false;
@@ -69,12 +107,13 @@ export async function storageFileExists(key: string): Promise<boolean> {
 
 /** Returns the byte size of a stored file. */
 export async function getStorageFileSize(key: string): Promise<number> {
-  const s3 = getS3Client();
-  if (!s3) {
+  const config = await getS3Config();
+  if (!config) {
     const stats = await stat(path.join(getUploadDir(), key));
     return stats.size;
   }
-  const res = await s3.send(new HeadObjectCommand({ Bucket: bucket(), Key: key }));
+  const s3 = buildS3Client(config);
+  const res = await s3.send(new HeadObjectCommand({ Bucket: config.bucket, Key: key }));
   return res.ContentLength ?? 0;
 }
 
@@ -83,25 +122,25 @@ export async function getStorageReadStream(
   key: string,
   range?: { start: number; end: number }
 ): Promise<Readable> {
-  const s3 = getS3Client();
-  if (!s3) {
+  const config = await getS3Config();
+  if (!config) {
     return createReadStream(path.join(getUploadDir(), key), range);
   }
+  const s3 = buildS3Client(config);
   const res = await s3.send(
     new GetObjectCommand({
-      Bucket: bucket(),
+      Bucket: config.bucket,
       Key: key,
       ...(range && { Range: `bytes=${range.start}-${range.end}` }),
     })
   );
-  // In Node.js, the AWS SDK returns a Node.js Readable stream
   return res.Body as unknown as Readable;
 }
 
 /** Deletes a file from storage (local or S3). Silently ignores missing files. */
 export async function deleteFromStorage(key: string): Promise<void> {
-  const s3 = getS3Client();
-  if (!s3) {
+  const config = await getS3Config();
+  if (!config) {
     try {
       await unlink(path.join(getUploadDir(), key));
     } catch (e) {
@@ -109,5 +148,6 @@ export async function deleteFromStorage(key: string): Promise<void> {
     }
     return;
   }
-  await s3.send(new DeleteObjectCommand({ Bucket: bucket(), Key: key }));
+  const s3 = buildS3Client(config);
+  await s3.send(new DeleteObjectCommand({ Bucket: config.bucket, Key: key }));
 }


### PR DESCRIPTION
## Summary

- Adds an optional storage abstraction layer (`src/lib/storage.ts`) that transparently routes all file I/O to either the local filesystem or an S3-compatible backend
- When `S3_BUCKET` is set, uploaded files are pushed to S3 after the tus handoff and the local copy is removed; all downloads, previews, bulk-zips, quota checks, and cleanup operate against S3
- Compatible with AWS S3, MinIO, Garage, Cloudflare R2, Scaleway Object Storage, and any other S3-compatible service via `S3_ENDPOINT` + `forcePathStyle`
- **Zero behavioural change** when `S3_BUCKET` is not configured — local filesystem works exactly as before, no migration needed

## New environment variables (all optional)

| Variable | Description |
|---|---|
| `S3_BUCKET` | Bucket name — enables S3 mode when set |
| `S3_REGION` | Region (default: `us-east-1`) |
| `S3_ACCESS_KEY_ID` | Access key |
| `S3_SECRET_ACCESS_KEY` | Secret key |
| `S3_ENDPOINT` | Custom endpoint for MinIO, Garage, R2, etc. |

## Test plan

- [ ] Upload a file with S3 disabled — verify it lands in `uploads/` as before
- [ ] Set `S3_BUCKET` + credentials, upload a file — verify it appears in the bucket and local copy is deleted
- [ ] Download, preview, and bulk-zip with S3 enabled
- [ ] Expire a share and run cleanup — verify S3 object is deleted
- [ ] Test with MinIO (`S3_ENDPOINT=http://minio:9000`)
- [ ] `npm run type-check` passes
- [ ] All unit tests pass (`npx jest fileshare`)