### PR TITLE
feat: add configurable default tab per user

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,9 @@ model User {
   password      String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
-  isAdmin       Boolean   @default(false)
-  ssoAutoLink   Boolean   @default(false)
+  isAdmin       Boolean    @default(false)
+  ssoAutoLink   Boolean    @default(false)
+  defaultTab    DefaultTab @default(linkshare)
   accounts      Account[]
   sessions      Session[]
   shares        Share[]
@@ -202,6 +203,12 @@ enum ShareType {
   FILE
   PASTE
   URL
+}
+
+enum DefaultTab {
+  linkshare
+  pasteshare
+  fileshare
 }
 
 model IpLocalisation {

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -23,6 +23,7 @@ export async function GET(request: NextRequest) {
         image: true,
         createdAt: true,
         isAdmin: true,
+        defaultTab: true,
       },
     });
 
@@ -47,7 +48,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     const data = await request.json();
-    const { name, email, currentPassword, newPassword } = data;
+    const { name, email, currentPassword, newPassword, defaultTab } = data;
 
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
@@ -57,15 +58,23 @@ export async function PATCH(request: NextRequest) {
       return apiError(request, ErrorCode.USER_NOT_FOUND);
     }
 
+    const VALID_TABS = ["linkshare", "pasteshare", "fileshare"];
     const updateData: {
       name?: string;
       email?: string;
       password?: string;
+      defaultTab?: "linkshare" | "pasteshare" | "fileshare";
     } = {};
 
-    // Mise à jour du nom
     if (name !== undefined) {
       updateData.name = name;
+    }
+
+    if (defaultTab !== undefined) {
+      if (!VALID_TABS.includes(defaultTab)) {
+        return apiError(request, ErrorCode.INVALID_REQUEST);
+      }
+      updateData.defaultTab = defaultTab;
     }
 
     // Mise à jour de l'email
@@ -109,6 +118,7 @@ export async function PATCH(request: NextRequest) {
         email: true,
         image: true,
         createdAt: true,
+        defaultTab: true,
       },
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Navigation from "@/components/Navigation";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
+import { useSession } from "next-auth/react";
 import LinkShare from "@/components/LinkShare";
 import PasteShare from "@/components/PasteShare";
 import FileShare from "@/components/FileShare";
@@ -17,6 +18,17 @@ export default function Home() {
   const [activeTab, setActiveTab] = useState("linkshare");
   const { t } = useTranslation();
   const { colors, branding } = useTheme();
+  const { status } = useSession();
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    fetch("/api/user/profile")
+      .then((res) => res.ok ? res.json() : null)
+      .then((data) => {
+        if (data?.user?.defaultTab) setActiveTab(data.user.defaultTab);
+      })
+      .catch(() => {});
+  }, [status]);
 
   const tabs = useMemo(
     () => [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Navigation from "@/components/Navigation";
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useLayoutEffect } from "react";
 import { useSession } from "next-auth/react";
 import LinkShare from "@/components/LinkShare";
 import PasteShare from "@/components/PasteShare";
@@ -15,13 +15,15 @@ const PASTE_SHARE = <PasteShare />;
 const FILE_SHARE = <FileShare />;
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState(() => {
-    if (typeof window === "undefined") return "linkshare";
-    return localStorage.getItem("defaultTab") ?? "linkshare";
-  });
+  const [activeTab, setActiveTab] = useState("linkshare");
   const { t } = useTranslation();
   const { colors, branding } = useTheme();
   const { status } = useSession();
+
+  useLayoutEffect(() => {
+    const saved = localStorage.getItem("defaultTab");
+    if (saved) setActiveTab(saved);
+  }, []);
 
   useEffect(() => {
     if (status !== "authenticated") return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,10 @@ const PASTE_SHARE = <PasteShare />;
 const FILE_SHARE = <FileShare />;
 
 export default function Home() {
-  const [activeTab, setActiveTab] = useState("linkshare");
+  const [activeTab, setActiveTab] = useState(() => {
+    if (typeof window === "undefined") return "linkshare";
+    return localStorage.getItem("defaultTab") ?? "linkshare";
+  });
   const { t } = useTranslation();
   const { colors, branding } = useTheme();
   const { status } = useSession();
@@ -23,9 +26,12 @@ export default function Home() {
   useEffect(() => {
     if (status !== "authenticated") return;
     fetch("/api/user/profile")
-      .then((res) => res.ok ? res.json() : null)
+      .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (data?.user?.defaultTab) setActiveTab(data.user.defaultTab);
+        if (data?.user?.defaultTab) {
+          setActiveTab(data.user.defaultTab);
+          localStorage.setItem("defaultTab", data.user.defaultTab);
+        }
       })
       .catch(() => {});
   }, [status]);

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -8,6 +8,7 @@ type User = {
   name?: string;
   email: string;
   createdAt: string;
+  defaultTab?: string;
 };
 
 type ProfileInfoProps = {
@@ -19,6 +20,7 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
   const { t } = useTranslation();
   const [name, setName] = useState(user.name || "");
   const [email, setEmail] = useState(user.email);
+  const [defaultTab, setDefaultTab] = useState(user.defaultTab || "linkshare");
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -49,7 +51,8 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
         email?: string;
         currentPassword?: string;
         newPassword?: string;
-      } = { name, email };
+        defaultTab?: string;
+      } = { name, email, defaultTab };
 
       if (newPassword) {
         updateData.currentPassword = currentPassword;
@@ -136,6 +139,24 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
               className="w-full px-3 py-2 rounded-lg bg-[var(--background)] border border-[var(--border)] text-[var(--foreground)] text-sm focus:outline-none focus:border-[var(--primary)]"
               required
             />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
+              {t("profile.default_tab")}
+            </label>
+            <p className="text-xs text-[var(--foreground-muted)] mb-2">
+              {t("profile.default_tab_desc")}
+            </p>
+            <select
+              value={defaultTab}
+              onChange={(e) => setDefaultTab(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg bg-[var(--background)] border border-[var(--border)] text-[var(--foreground)] text-sm focus:outline-none focus:border-[var(--primary)]"
+            >
+              <option value="linkshare">{t("profile.default_tab_linkshare")}</option>
+              <option value="pasteshare">{t("profile.default_tab_pasteshare")}</option>
+              <option value="fileshare">{t("profile.default_tab_fileshare")}</option>
+            </select>
           </div>
         </div>
 

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -70,6 +70,7 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
       if (res.ok) {
         setMessage(t("profile.success_update"));
         onUpdate(data.user);
+        localStorage.setItem("defaultTab", defaultTab);
         setCurrentPassword("");
         setNewPassword("");
         setConfirmPassword("");

--- a/src/components/shareComponents/AdvancedSettings.tsx
+++ b/src/components/shareComponents/AdvancedSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
 interface AdvancedSettingsProps {
@@ -26,6 +26,11 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
   passwordLabelKey,
 }) => {
   const { t } = useTranslation();
+  const [origin, setOrigin] = useState("");
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   return (
     <div className="bg-[var(--surface)]/50 p-4 rounded-xl border border-[var(--border)]/50 space-y-4">
@@ -48,7 +53,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
           </label>
           <div className="flex flex-col sm:flex-row sm:items-center items-start gap-2">
             <span className="text-sm text-[var(--foreground-muted)] whitespace-nowrap">
-              {typeof window !== "undefined" ? window.location.origin + slugPrefix : slugPrefix}
+              {origin + slugPrefix}
             </span>
             <input
               id="slug"

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -45,7 +45,7 @@ export function useFetch<T>(url: string | null, options?: FetchOptions): FetchSt
           return res.json() as Promise<T>;
         });
         inflightRequests.set(url, promise);
-        promise.finally(() => inflightRequests.delete(url));
+        promise.finally(() => inflightRequests.delete(url)).catch(() => {});
       }
       const json = await promise;
       if (id === counterRef.current) {
@@ -55,8 +55,7 @@ export function useFetch<T>(url: string | null, options?: FetchOptions): FetchSt
       if (err instanceof Error && err.name === "AbortError") return;
       if (id === counterRef.current) {
         setError(
-          optionsRef.current?.errorMessage ??
-            (err instanceof Error ? err.message : "Unknown error")
+          optionsRef.current?.errorMessage ?? (err instanceof Error ? err.message : "Unknown error")
         );
       }
     } finally {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -316,7 +316,12 @@
       "error_unlink": "Fehler beim Trennen des Kontos",
       "unlink_success": "Konto erfolgreich getrennt"
     },
-    "tab_apikeys": "API-Schlüssel"
+    "tab_apikeys": "API-Schlüssel",
+    "default_tab": "Standard-Tab",
+    "default_tab_desc": "Standardmäßig angezeigter Tab auf der Startseite",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "API-Schlüssel",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -320,7 +320,12 @@
       "error_unlink": "Error unlinking account",
       "unlink_success": "Account unlinked successfully"
     },
-    "tab_apikeys": "API Keys"
+    "tab_apikeys": "API Keys",
+    "default_tab": "Default tab",
+    "default_tab_desc": "Tab shown by default on the home page",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "API Keys",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -316,7 +316,12 @@
       "error_unlink": "Error al desvincular la cuenta",
       "unlink_success": "Cuenta desvinculada con éxito"
     },
-    "tab_apikeys": "Claves API"
+    "tab_apikeys": "Claves API",
+    "default_tab": "Pestaña predeterminada",
+    "default_tab_desc": "Pestaña mostrada por defecto en la página de inicio",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "Claves API",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -320,7 +320,12 @@
       "error_unlink": "Erreur lors de la suppression du compte",
       "unlink_success": "Compte délié avec succès"
     },
-    "tab_apikeys": "Clés API"
+    "tab_apikeys": "Clés API",
+    "default_tab": "Onglet par défaut",
+    "default_tab_desc": "Onglet affiché par défaut sur la page d'accueil",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "Clés API",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -324,7 +324,12 @@
       "error_unlink": "Fout bij het verwijderen van account",
       "unlink_success": "Account succesvol ontkoppeld"
     },
-    "tab_apikeys": "API-sleutels"
+    "tab_apikeys": "API-sleutels",
+    "default_tab": "Standaard tabblad",
+    "default_tab_desc": "Tabblad dat standaard wordt weergegeven op de startpagina",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "API-sleutels",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -324,7 +324,12 @@
       "error_unlink": "Błąd usuwania konta",
       "unlink_success": "Konto rozłączone pomyślnie"
     },
-    "tab_apikeys": "Klucze API"
+    "tab_apikeys": "Klucze API",
+    "default_tab": "Domyślna zakładka",
+    "default_tab_desc": "Zakładka wyświetlana domyślnie na stronie głównej",
+    "default_tab_linkshare": "LinkShare",
+    "default_tab_pasteshare": "PasteShare",
+    "default_tab_fileshare": "FileShare"
   },
   "apikeys": {
     "title": "Klucze API",


### PR DESCRIPTION
Closes #251

## Summary

- Add `DefaultTab` enum to Prisma schema (`linkshare`, `pasteshare`, `fileshare`)
- Add `defaultTab` field to `User` model (default: `linkshare`)
- Expose and update `defaultTab` via `GET`/`PATCH /api/user/profile`
- Add tab selector in profile settings (Personal information tab)
- Home page reads user preference on load and sets the active tab accordingly
- i18n keys added to all 6 locales (en, fr, es, de, nl, pl)

## Test plan

- [ ] Go to Profile → Personal information, change the default tab to FileShare, save
- [ ] Return to the home page → FileShare should be active by default
- [ ] Verify that unauthenticated users still see LinkShare by default