### PR TITLE
fix: clean abandoned tus uploads and orphan files (closes #258)

### DIFF
--- a/scripts/cleanup-expired-shares.ts
+++ b/scripts/cleanup-expired-shares.ts
@@ -8,95 +8,201 @@ function getUploadDir(): string {
   return process.env.UPLOAD_DIR || path.join(process.cwd(), "uploads");
 }
 
-async function cleanupExpiredShares() {
-  console.log("🧹 Starting cleanup of expired shares...");
+function getTusTempDir(): string {
+  return path.join(getUploadDir(), ".tus-temp");
+}
+
+// Files in .tus-temp/ older than this are considered abandoned uploads.
+const TUS_TEMP_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Files in uploads/ without a DB record are only deleted after this grace
+// period to avoid racing with in-flight uploads that have not yet inserted
+// their database row.
+const ORPHAN_GRACE_MS = 60 * 60 * 1000; // 1 hour
+
+async function cleanupExpiredShares(): Promise<{ deletedShares: number; deletedFiles: number }> {
+  console.log("🧹 Cleaning expired shares...");
+
+  const now = new Date();
+
+  const expiredShares = await prisma.share.findMany({
+    where: { expiresAt: { lt: now } },
+    select: {
+      id: true,
+      type: true,
+      filePath: true,
+      slug: true,
+      isBulk: true,
+      files: { select: { filePath: true } },
+    },
+  });
+
+  console.log(`📊 ${expiredShares.length} expired share(s) found`);
+
+  if (expiredShares.length === 0) {
+    return { deletedShares: 0, deletedFiles: 0 };
+  }
+
+  let deletedFiles = 0;
+
+  const deleteFileIfExists = async (relativePath: string, shareSlug: string): Promise<void> => {
+    const fullFilePath = path.join(getUploadDir(), relativePath);
+    try {
+      await fs.promises.unlink(fullFilePath);
+      deletedFiles++;
+      console.log(`🗑️  File deleted: ${relativePath} (share: ${shareSlug})`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(`❌ Error deleting file ${relativePath}:`, error);
+      }
+    }
+  };
+
+  for (const share of expiredShares) {
+    if (share.type !== "FILE") continue;
+    if (share.isBulk && share.files.length > 0) {
+      await Promise.all(share.files.map((file) => deleteFileIfExists(file.filePath, share.slug)));
+    } else if (share.filePath) {
+      await deleteFileIfExists(share.filePath, share.slug);
+    }
+  }
+
+  const deleteResult = await prisma.share.deleteMany({
+    where: { expiresAt: { lt: now } },
+  });
+
+  console.log(
+    `✅ Expired shares: ${deleteResult.count} DB record(s), ${deletedFiles} file(s) deleted`
+  );
+
+  return { deletedShares: deleteResult.count, deletedFiles };
+}
+
+async function cleanupAbandonedTusUploads(
+  maxAgeMs: number = TUS_TEMP_MAX_AGE_MS
+): Promise<{ deletedFiles: number }> {
+  console.log("🧹 Cleaning abandoned tus uploads...");
+
+  const tusTempDir = getTusTempDir();
+  let entries: fs.Dirent[];
 
   try {
-    const now = new Date();
-
-    const expiredShares = await prisma.share.findMany({
-      where: {
-        expiresAt: {
-          lt: now,
-        },
-      },
-      select: {
-        id: true,
-        type: true,
-        filePath: true,
-        slug: true,
-        createdAt: true,
-        expiresAt: true,
-        isBulk: true,
-        files: {
-          select: {
-            filePath: true,
-          },
-        },
-      },
-    });
-
-    console.log(`📊 ${expiredShares.length} expired share(s) found`);
-
-    if (expiredShares.length === 0) {
-      console.log("✨ No expired shares to clean up");
-      return;
-    }
-
-    let deletedFiles = 0;
-    let deletedShares = 0;
-
-    const deleteFileIfExists = async (
-      relativePath: string,
-      shareSlug: string
-    ): Promise<boolean> => {
-      const fullFilePath = path.join(getUploadDir(), relativePath);
-
-      try {
-        await fs.promises.access(fullFilePath, fs.constants.F_OK);
-        await fs.promises.unlink(fullFilePath);
-        deletedFiles++;
-        console.log(`🗑️  File deleted: ${relativePath} (share: ${shareSlug})`);
-        return true;
-      } catch (error) {
-        // Access throws if the file does not exist; ignore ENOENT but surface other errors for visibility.
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          console.error(`❌ Error deleting file ${relativePath}:`, error);
-        }
-        return false;
-      }
-    };
-
-    for (const share of expiredShares) {
-      if (share.type === "FILE") {
-        if (share.isBulk && share.files) {
-          const bulkDeletionTasks = share.files.map((file) =>
-            deleteFileIfExists(file.filePath, share.slug)
-          );
-          await Promise.all(bulkDeletionTasks);
-        } else if (share.filePath) {
-          await deleteFileIfExists(share.filePath, share.slug);
-        }
-      }
-    }
-
-    // Delete database records
-    const deleteResult = await prisma.share.deleteMany({
-      where: {
-        expiresAt: {
-          lt: now,
-        },
-      },
-    });
-
-    deletedShares = deleteResult.count;
-
-    console.log(`✅ Cleanup completed:`);
-    console.log(`   - ${deletedShares} share(s) deleted from the database`);
-    console.log(`   - ${deletedFiles} physical file(s) deleted`);
+    entries = await fs.promises.readdir(tusTempDir, { withFileTypes: true });
   } catch (error) {
-    console.error("❌ Error during cleanup of expired shares:", error);
-    process.exit(1);
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log("ℹ️  No .tus-temp directory, skipping");
+      return { deletedFiles: 0 };
+    }
+    throw error;
+  }
+
+  const cutoff = Date.now() - maxAgeMs;
+  let deletedFiles = 0;
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isFile()) return;
+      const fullPath = path.join(tusTempDir, entry.name);
+      try {
+        const stat = await fs.promises.stat(fullPath);
+        if (stat.mtimeMs >= cutoff) return;
+        await fs.promises.unlink(fullPath);
+        deletedFiles++;
+        console.log(`🗑️  Abandoned tus file deleted: ${entry.name}`);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          console.error(`❌ Error deleting tus file ${entry.name}:`, error);
+        }
+      }
+    })
+  );
+
+  console.log(`✅ Abandoned tus uploads: ${deletedFiles} file(s) deleted`);
+  return { deletedFiles };
+}
+
+async function cleanupOrphanFiles(
+  graceMs: number = ORPHAN_GRACE_MS
+): Promise<{ deletedFiles: number }> {
+  console.log("🧹 Cleaning orphan files in uploads/...");
+
+  const uploadDir = getUploadDir();
+  let entries: fs.Dirent[];
+
+  try {
+    entries = await fs.promises.readdir(uploadDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      console.log("ℹ️  No uploads directory, skipping");
+      return { deletedFiles: 0 };
+    }
+    throw error;
+  }
+
+  const fileEntries = entries.filter((entry) => entry.isFile() && !entry.name.startsWith("."));
+
+  if (fileEntries.length === 0) {
+    return { deletedFiles: 0 };
+  }
+
+  const [shareRows, shareFileRows] = await Promise.all([
+    prisma.share.findMany({
+      where: { filePath: { not: null } },
+      select: { filePath: true },
+    }),
+    prisma.shareFile.findMany({ select: { filePath: true } }),
+  ]);
+
+  const referenced = new Set<string>();
+  for (const row of shareRows) {
+    if (row.filePath) referenced.add(row.filePath);
+  }
+  for (const row of shareFileRows) {
+    referenced.add(row.filePath);
+  }
+
+  const cutoff = Date.now() - graceMs;
+  let deletedFiles = 0;
+
+  await Promise.all(
+    fileEntries.map(async (entry) => {
+      if (referenced.has(entry.name)) return;
+      const fullPath = path.join(uploadDir, entry.name);
+      try {
+        const stat = await fs.promises.stat(fullPath);
+        if (stat.mtimeMs >= cutoff) return;
+        await fs.promises.unlink(fullPath);
+        deletedFiles++;
+        console.log(`🗑️  Orphan file deleted: ${entry.name}`);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          console.error(`❌ Error deleting orphan ${entry.name}:`, error);
+        }
+      }
+    })
+  );
+
+  console.log(`✅ Orphan files: ${deletedFiles} file(s) deleted`);
+  return { deletedFiles };
+}
+
+async function runCleanup(): Promise<void> {
+  console.log("🚀 Starting full cleanup...");
+
+  try {
+    const expired = await cleanupExpiredShares();
+    const abandoned = await cleanupAbandonedTusUploads();
+    const orphans = await cleanupOrphanFiles();
+
+    console.log("");
+    console.log("📊 Summary:");
+    console.log(`   - ${expired.deletedShares} expired share(s) removed from DB`);
+    console.log(`   - ${expired.deletedFiles} expired share file(s) deleted`);
+    console.log(`   - ${abandoned.deletedFiles} abandoned tus upload(s) deleted`);
+    console.log(`   - ${orphans.deletedFiles} orphan file(s) deleted`);
+  } catch (error) {
+    console.error("❌ Error during cleanup:", error);
+    throw error;
   }
 }
 
@@ -106,7 +212,7 @@ const isMain =
   (process.argv[1].endsWith("cleanup-expired-shares.ts") ||
     process.argv[1].endsWith("cleanup-expired-shares.js"));
 if (isMain) {
-  cleanupExpiredShares()
+  runCleanup()
     .then(async () => {
       console.log("🎉 Cleanup completed successfully");
       await prisma.$disconnect();
@@ -119,4 +225,5 @@ if (isMain) {
     });
 }
 
+export { cleanupExpiredShares, cleanupAbandonedTusUploads, cleanupOrphanFiles, runCleanup };
 export default cleanupExpiredShares;

--- a/src/__tests__/scripts/cleanup-expired-shares.test.ts
+++ b/src/__tests__/scripts/cleanup-expired-shares.test.ts
@@ -1,0 +1,286 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    share: {
+      findMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    shareFile: {
+      findMany: jest.fn(),
+    },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { prisma } from "@/lib/prisma";
+import {
+  cleanupExpiredShares,
+  cleanupAbandonedTusUploads,
+  cleanupOrphanFiles,
+} from "../../../scripts/cleanup-expired-shares";
+
+const mockShareFindMany = prisma.share.findMany as jest.Mock;
+const mockShareDeleteMany = prisma.share.deleteMany as jest.Mock;
+const mockShareFileFindMany = prisma.shareFile.findMany as jest.Mock;
+
+let tempUploadDir: string;
+let originalUploadDir: string | undefined;
+
+// Set mtime in the past so the file looks "old" enough to be cleaned.
+function ageFile(filePath: string, ageMs: number): void {
+  const past = new Date(Date.now() - ageMs);
+  fs.utimesSync(filePath, past, past);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+
+  tempUploadDir = fs.mkdtempSync(path.join(os.tmpdir(), "snowshare-cleanup-test-"));
+  originalUploadDir = process.env.UPLOAD_DIR;
+  process.env.UPLOAD_DIR = tempUploadDir;
+
+  mockShareFindMany.mockResolvedValue([]);
+  mockShareDeleteMany.mockResolvedValue({ count: 0 });
+  mockShareFileFindMany.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  if (originalUploadDir === undefined) {
+    delete process.env.UPLOAD_DIR;
+  } else {
+    process.env.UPLOAD_DIR = originalUploadDir;
+  }
+  fs.rmSync(tempUploadDir, { recursive: true, force: true });
+});
+
+describe("cleanupExpiredShares", () => {
+  it("deletes physical files for expired single-file shares", async () => {
+    const fileName = "share-1_doc.pdf";
+    const filePath = path.join(tempUploadDir, fileName);
+    fs.writeFileSync(filePath, "content");
+
+    mockShareFindMany.mockResolvedValue([
+      {
+        id: "share-1",
+        type: "FILE",
+        filePath: fileName,
+        slug: "my-share",
+        isBulk: false,
+        files: [],
+      },
+    ]);
+    mockShareDeleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await cleanupExpiredShares();
+
+    expect(result).toEqual({ deletedShares: 1, deletedFiles: 1 });
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(mockShareDeleteMany).toHaveBeenCalledWith({
+      where: { expiresAt: { lt: expect.any(Date) } },
+    });
+  });
+
+  it("deletes all files for expired bulk shares", async () => {
+    const file1 = "share-2_a.txt";
+    const file2 = "share-2_b.txt";
+    fs.writeFileSync(path.join(tempUploadDir, file1), "a");
+    fs.writeFileSync(path.join(tempUploadDir, file2), "b");
+
+    mockShareFindMany.mockResolvedValue([
+      {
+        id: "share-2",
+        type: "FILE",
+        filePath: null,
+        slug: "bulk-share",
+        isBulk: true,
+        files: [{ filePath: file1 }, { filePath: file2 }],
+      },
+    ]);
+    mockShareDeleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await cleanupExpiredShares();
+
+    expect(result.deletedFiles).toBe(2);
+    expect(fs.existsSync(path.join(tempUploadDir, file1))).toBe(false);
+    expect(fs.existsSync(path.join(tempUploadDir, file2))).toBe(false);
+  });
+
+  it("ignores expired non-FILE shares but still deletes DB records", async () => {
+    mockShareFindMany.mockResolvedValue([
+      {
+        id: "share-3",
+        type: "URL",
+        filePath: null,
+        slug: "link-share",
+        isBulk: false,
+        files: [],
+      },
+    ]);
+    mockShareDeleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await cleanupExpiredShares();
+
+    expect(result).toEqual({ deletedShares: 1, deletedFiles: 0 });
+  });
+
+  it("returns zero counts when no shares are expired", async () => {
+    const result = await cleanupExpiredShares();
+
+    expect(result).toEqual({ deletedShares: 0, deletedFiles: 0 });
+    expect(mockShareDeleteMany).not.toHaveBeenCalled();
+  });
+
+  it("handles missing files gracefully (ENOENT)", async () => {
+    mockShareFindMany.mockResolvedValue([
+      {
+        id: "share-4",
+        type: "FILE",
+        filePath: "does-not-exist.bin",
+        slug: "missing",
+        isBulk: false,
+        files: [],
+      },
+    ]);
+    mockShareDeleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await cleanupExpiredShares();
+
+    expect(result).toEqual({ deletedShares: 1, deletedFiles: 0 });
+  });
+});
+
+describe("cleanupAbandonedTusUploads", () => {
+  it("deletes tus-temp files older than the max age", async () => {
+    const tusDir = path.join(tempUploadDir, ".tus-temp");
+    fs.mkdirSync(tusDir);
+
+    const oldFile = path.join(tusDir, "abandoned-upload-id");
+    const oldMeta = path.join(tusDir, "abandoned-upload-id.json");
+    fs.writeFileSync(oldFile, "partial data");
+    fs.writeFileSync(oldMeta, "{}");
+    ageFile(oldFile, 25 * 60 * 60 * 1000);
+    ageFile(oldMeta, 25 * 60 * 60 * 1000);
+
+    const result = await cleanupAbandonedTusUploads();
+
+    expect(result.deletedFiles).toBe(2);
+    expect(fs.existsSync(oldFile)).toBe(false);
+    expect(fs.existsSync(oldMeta)).toBe(false);
+  });
+
+  it("preserves tus-temp files newer than the max age (in-flight uploads)", async () => {
+    const tusDir = path.join(tempUploadDir, ".tus-temp");
+    fs.mkdirSync(tusDir);
+
+    const recentFile = path.join(tusDir, "in-flight-upload-id");
+    fs.writeFileSync(recentFile, "partial data");
+
+    const result = await cleanupAbandonedTusUploads();
+
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(recentFile)).toBe(true);
+  });
+
+  it("returns zero when .tus-temp does not exist", async () => {
+    const result = await cleanupAbandonedTusUploads();
+
+    expect(result).toEqual({ deletedFiles: 0 });
+  });
+
+  it("respects the maxAgeMs argument", async () => {
+    const tusDir = path.join(tempUploadDir, ".tus-temp");
+    fs.mkdirSync(tusDir);
+
+    const file = path.join(tusDir, "upload-id");
+    fs.writeFileSync(file, "data");
+    ageFile(file, 2000); // 2 seconds old
+
+    const result = await cleanupAbandonedTusUploads(1000); // 1 second threshold
+
+    expect(result.deletedFiles).toBe(1);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+});
+
+describe("cleanupOrphanFiles", () => {
+  it("deletes old files in uploads/ with no DB record", async () => {
+    const orphan = path.join(tempUploadDir, "share-99_orphan.bin");
+    fs.writeFileSync(orphan, "stale data");
+    ageFile(orphan, 2 * 60 * 60 * 1000); // 2 hours old
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result.deletedFiles).toBe(1);
+    expect(fs.existsSync(orphan)).toBe(false);
+  });
+
+  it("preserves files that have a Share.filePath reference", async () => {
+    const referenced = path.join(tempUploadDir, "share-1_keep.bin");
+    fs.writeFileSync(referenced, "real data");
+    ageFile(referenced, 2 * 60 * 60 * 1000);
+
+    mockShareFindMany.mockResolvedValue([{ filePath: "share-1_keep.bin" }]);
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(referenced)).toBe(true);
+  });
+
+  it("preserves files that have a ShareFile.filePath reference", async () => {
+    const referenced = path.join(tempUploadDir, "share-2_bulk.bin");
+    fs.writeFileSync(referenced, "bulk data");
+    ageFile(referenced, 2 * 60 * 60 * 1000);
+
+    mockShareFileFindMany.mockResolvedValue([{ filePath: "share-2_bulk.bin" }]);
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(referenced)).toBe(true);
+  });
+
+  it("preserves recent orphans (grace period for in-flight uploads)", async () => {
+    const recent = path.join(tempUploadDir, "share-3_new.bin");
+    fs.writeFileSync(recent, "just uploaded");
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(recent)).toBe(true);
+  });
+
+  it("skips dotfiles and subdirectories like .tus-temp/", async () => {
+    fs.mkdirSync(path.join(tempUploadDir, ".tus-temp"));
+    fs.writeFileSync(path.join(tempUploadDir, ".tus-temp", "in-progress"), "data");
+
+    const dotfile = path.join(tempUploadDir, ".hidden");
+    fs.writeFileSync(dotfile, "x");
+    ageFile(dotfile, 2 * 60 * 60 * 1000);
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result.deletedFiles).toBe(0);
+    expect(fs.existsSync(dotfile)).toBe(true);
+  });
+
+  it("returns zero when uploads/ does not exist", async () => {
+    fs.rmSync(tempUploadDir, { recursive: true, force: true });
+
+    const result = await cleanupOrphanFiles();
+
+    expect(result).toEqual({ deletedFiles: 0 });
+
+    // Recreate so afterEach cleanup does not fail
+    fs.mkdirSync(tempUploadDir);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the snowshare side of issue #258 where storage stays full even after expired shares are cleaned.

The cleanup script previously only removed files for **expired** shares, leaving two sources of garbage to accumulate indefinitely:

1. **Abandoned tus uploads** in `.tus-temp/` — when a client disconnects mid-upload, `onUploadFinish` is never called and the partial file + its `.json` metadata stay forever.
2. **Orphan files** in `uploads/` — files with no corresponding database record (e.g. after manual DB cleanup or a failed insert).

## Changes

- `cleanupAbandonedTusUploads()` — deletes `.tus-temp/` entries older than 24 h
- `cleanupOrphanFiles()` — deletes `uploads/` files with no `Share.filePath` / `ShareFile.filePath` reference, with a 1 h grace period to avoid racing with in-flight uploads
- `runCleanup()` — orchestrates the three steps and prints a global summary
- `cleanupExpiredShares()` — same behavior, returns counts instead of just logging
- 15 unit tests covering all three cleanup paths (uses real filesystem in `os.tmpdir()`, Prisma mocked)

## Notes

A separate bug exists in the Proxmox community install script (`cp -a` instead of `mv` during update, and the `.snowshare_uploads_backup` is never cleaned up). That part will be addressed in a separate PR against `community-scripts/ProxmoxVE`.