### PR TITLE
refactor(admin): extract settings sections into controlled components

### DIFF
--- a/server.js
+++ b/server.js
@@ -159,7 +159,7 @@ async function generateSafeFilename(originalName, shareId) {
 }
 
 // Calculate IP usage for quota (single + bulk uploads)
-async function calculateIpUsage(prisma, clientIp, uploadsDir) {
+async function calculateIpUsage(prisma, clientIp, _uploadsDir) {
   const shares = await prisma.share.findMany({
     where: { ipSource: clientIp, type: "FILE" },
     select: {
@@ -417,7 +417,7 @@ const tusServer = new TusServer({
   maxSize: 1024 * 1024 * 1024 * 1024, // 1TB absolute max
   // Expose custom headers to client
   respectForwardedHeaders: true,
-  generateUrl(req, { proto, host, path, id }) {
+  generateUrl(req, { proto: _proto, host: _host, path, id }) {
     // Use relative URL to avoid protocol mismatch behind reverse proxies (CSP 'self')
     return `${path}/${id}`;
   },

--- a/src/components/FileShare.tsx
+++ b/src/components/FileShare.tsx
@@ -16,8 +16,6 @@ import SubmitButton from "./shareComponents/SubmitButton";
 
 const MAX_DAYS_ANON = 7;
 const MAX_DAYS_AUTH = 365;
-const MAX_FILE_SIZE_ANON = 50 * 1024 * 1024; // 50MB
-const MAX_FILE_SIZE_AUTH = 500 * 1024 * 1024; // 500MB
 
 interface FileWithPath {
   file: File;

--- a/src/components/admin/CaptchaSection.tsx
+++ b/src/components/admin/CaptchaSection.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { FieldInput, ToggleRow } from "./settings/primitives";
+
+export interface CaptchaSectionSettings {
+  captchaEnabled: boolean;
+  captchaProvider: string | null;
+  captchaSiteKey: string | null;
+  captchaSecretKey: string | null;
+}
+
+interface Props {
+  settings: CaptchaSectionSettings;
+  onChange: (patch: Partial<CaptchaSectionSettings>) => void;
+}
+
+export default function CaptchaSection({ settings, onChange }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-[var(--foreground)]">
+        {t("admin.settings.section_captcha")}
+      </h3>
+
+      <ToggleRow
+        label={t("admin.settings.captcha_enabled")}
+        description={t("admin.settings.captcha_enabled_desc")}
+        checked={settings.captchaEnabled}
+        onChange={() => onChange({ captchaEnabled: !settings.captchaEnabled })}
+      />
+
+      {settings.captchaEnabled && (
+        <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+          <div>
+            <label className="text-sm font-medium text-[var(--foreground)]">
+              {t("admin.settings.captcha_provider")}
+            </label>
+            <select
+              value={settings.captchaProvider ?? ""}
+              onChange={(e) => onChange({ captchaProvider: e.target.value || null })}
+              className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+            >
+              <option value="">{t("admin.settings.captcha_provider_select")}</option>
+              <option value="recaptcha">Google reCAPTCHA v2</option>
+              <option value="turnstile">Cloudflare Turnstile</option>
+            </select>
+          </div>
+
+          <FieldInput
+            label={t("admin.settings.captcha_site_key")}
+            value={settings.captchaSiteKey ?? ""}
+            onChange={(v) => onChange({ captchaSiteKey: v })}
+            placeholder={t("admin.settings.captcha_site_key_placeholder") as string}
+          />
+
+          <FieldInput
+            label={t("admin.settings.captcha_secret_key")}
+            type="password"
+            value={settings.captchaSecretKey ?? ""}
+            onChange={(v) => onChange({ captchaSecretKey: v })}
+            placeholder={t("admin.settings.captcha_secret_key_placeholder") as string}
+            hint={t("admin.settings.captcha_secret_key_hint") as string}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/GeneralSection.tsx
+++ b/src/components/admin/GeneralSection.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { ToggleRow } from "./settings/primitives";
+
+export interface GeneralSectionSettings {
+  allowSignin: boolean;
+  disableCredentialsLogin: boolean;
+  allowAnonFileShare: boolean;
+  allowAnonLinkShare: boolean;
+  allowAnonPasteShare: boolean;
+  allowIframeEmbedding: boolean;
+}
+
+interface Props {
+  settings: GeneralSectionSettings;
+  hasActiveSSO: boolean;
+  onChange: (patch: Partial<GeneralSectionSettings>) => void;
+  onRequestDisableCredentials: () => void;
+}
+
+export default function GeneralSection({
+  settings,
+  hasActiveSSO,
+  onChange,
+  onRequestDisableCredentials,
+}: Props) {
+  const { t } = useTranslation();
+
+  const handleToggleDisableCredentials = () => {
+    if (!settings.disableCredentialsLogin) {
+      onRequestDisableCredentials();
+      return;
+    }
+    onChange({ disableCredentialsLogin: false });
+  };
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-[var(--foreground)]">
+        {t("admin.settings.section_general")}
+      </h3>
+
+      <ToggleRow
+        label={t("admin.settings.disable_credentials_login")}
+        description={t("admin.settings.disable_credentials_login_desc")}
+        extra={
+          !hasActiveSSO && (
+            <p className="text-xs text-red-400 mt-1">{t("admin.settings.no_sso_active")}</p>
+          )
+        }
+        checked={settings.disableCredentialsLogin}
+        onChange={handleToggleDisableCredentials}
+        disabled={!hasActiveSSO}
+      />
+
+      {!settings.disableCredentialsLogin && (
+        <ToggleRow
+          label={t("admin.settings.allow_signup")}
+          description={t("admin.settings.allow_signup_desc")}
+          checked={settings.allowSignin}
+          onChange={() => onChange({ allowSignin: !settings.allowSignin })}
+        />
+      )}
+
+      <ToggleRow
+        label={t("admin.settings.allow_anon_fileshare")}
+        description={t("admin.settings.allow_anon_fileshare_desc")}
+        checked={settings.allowAnonFileShare}
+        onChange={() => onChange({ allowAnonFileShare: !settings.allowAnonFileShare })}
+      />
+
+      <ToggleRow
+        label={t("admin.settings.allow_anon_linkshare")}
+        description={t("admin.settings.allow_anon_linkshare_desc")}
+        checked={settings.allowAnonLinkShare}
+        onChange={() => onChange({ allowAnonLinkShare: !settings.allowAnonLinkShare })}
+      />
+
+      <ToggleRow
+        label={t("admin.settings.allow_anon_pasteshare")}
+        description={t("admin.settings.allow_anon_pasteshare_desc")}
+        checked={settings.allowAnonPasteShare}
+        onChange={() => onChange({ allowAnonPasteShare: !settings.allowAnonPasteShare })}
+      />
+
+      <ToggleRow
+        label={t("admin.settings.allow_iframe_embedding")}
+        description={t("admin.settings.allow_iframe_embedding_desc")}
+        extra={
+          settings.allowIframeEmbedding && (
+            <p className="text-xs text-yellow-400 mt-1">
+              {t("admin.settings.allow_iframe_embedding_warning")}
+            </p>
+          )
+        }
+        checked={settings.allowIframeEmbedding}
+        onChange={() => onChange({ allowIframeEmbedding: !settings.allowIframeEmbedding })}
+        activeColor="bg-yellow-500"
+      />
+    </div>
+  );
+}

--- a/src/components/admin/OAuthProvidersTab.tsx
+++ b/src/components/admin/OAuthProvidersTab.tsx
@@ -17,7 +17,6 @@ import {
   FormControlLabel,
   Switch,
   Alert,
-  CircularProgress,
   IconButton,
 } from "@mui/material";
 import WaveSkeleton from "@/components/ui/WaveSkeleton";

--- a/src/components/admin/QuotasSection.tsx
+++ b/src/components/admin/QuotasSection.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { convertFromMB, convertToMB } from "@/lib/formatSize";
+
+export interface QuotasSectionSettings {
+  anoMaxUpload: number;
+  authMaxUpload: number;
+  anoIpQuota: number;
+  authIpQuota: number;
+  useGiBForAnon: boolean;
+  useGiBForAuth: boolean;
+}
+
+interface Props {
+  settings: QuotasSectionSettings;
+  onChange: (patch: Partial<QuotasSectionSettings>) => void;
+}
+
+interface QuotaInputProps {
+  label: string;
+  hint: string;
+  value: number;
+  onChange: (raw: number) => void;
+  unit: string;
+  currentValueLabel: string;
+}
+
+function QuotaInput({ label, hint, value, onChange, unit, currentValueLabel }: QuotaInputProps) {
+  return (
+    <div>
+      <label className="text-sm text-[var(--foreground)]">{label}</label>
+      <p className="text-xs text-[var(--foreground-muted)] mb-2">{hint}</p>
+      <div className="flex items-center gap-3">
+        <div className="flex-1">
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => onChange(parseInt(e.target.value))}
+            className="w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+            min="0"
+          />
+        </div>
+        <span className="text-sm text-[var(--foreground-muted)] whitespace-nowrap">{unit}</span>
+      </div>
+      <p className="text-xs text-[var(--foreground-muted)] mt-1">{currentValueLabel}</p>
+    </div>
+  );
+}
+
+interface QuotaGroupProps {
+  title: string;
+  iconBg: string;
+  iconBorder: string;
+  iconColor: string;
+  iconPath: string;
+  useGiB: boolean;
+  onToggleUnit: () => void;
+  maxUpload: number;
+  ipQuota: number;
+  onChangeMax: (raw: number) => void;
+  onChangeIp: (raw: number) => void;
+}
+
+function QuotaGroup({
+  title,
+  iconBg,
+  iconBorder,
+  iconColor,
+  iconPath,
+  useGiB,
+  onToggleUnit,
+  maxUpload,
+  ipQuota,
+  onChangeMax,
+  onChangeIp,
+}: QuotaGroupProps) {
+  const { t } = useTranslation();
+  const unit = useGiB ? "GiB" : "MiB";
+
+  return (
+    <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+      <div className="flex items-center gap-2 mb-2 justify-between">
+        <div className="flex items-center gap-2">
+          <div
+            className={`h-6 w-6 rounded-lg ${iconBg} border ${iconBorder} flex items-center justify-center`}
+          >
+            <svg
+              className={`w-3 h-3 ${iconColor}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={iconPath} />
+            </svg>
+          </div>
+          <label className="text-[var(--foreground)] font-medium">{title}</label>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-[var(--foreground-muted)]">
+            {t("admin.quotas.unit_format")}
+          </label>
+          <button
+            onClick={onToggleUnit}
+            className={`px-3 py-1 rounded-lg font-medium transition-all ${
+              useGiB
+                ? "bg-[var(--secondary)] text-white"
+                : "bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)]"
+            }`}
+          >
+            {unit}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <QuotaInput
+          label={t("admin.quotas.max_file_size")}
+          hint={t("admin.quotas.max_file_size_hint")}
+          value={convertFromMB(maxUpload, useGiB)}
+          onChange={onChangeMax}
+          unit={unit}
+          currentValueLabel={t("admin.quotas.current_value", {
+            value: convertFromMB(maxUpload, useGiB),
+          })}
+        />
+        <QuotaInput
+          label={t("admin.quotas.ip_quota")}
+          hint={t("admin.quotas.ip_quota_hint")}
+          value={convertFromMB(ipQuota, useGiB)}
+          onChange={onChangeIp}
+          unit={unit}
+          currentValueLabel={t("admin.quotas.current_value", {
+            value: convertFromMB(ipQuota, useGiB),
+          })}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function QuotasSection({ settings, onChange }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 mb-4">
+        <div className="h-8 w-8 rounded-lg bg-[var(--primary)]/20 border border-[var(--primary-dark)]/50 flex items-center justify-center">
+          <svg
+            className="w-4 h-4 text-[var(--primary)]"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+        <h3 className="text-lg font-semibold text-[var(--foreground)]">
+          {t("admin.quotas.title")}
+        </h3>
+      </div>
+
+      <QuotaGroup
+        title={t("admin.quotas.section_anonymous")}
+        iconBg="bg-[var(--primary)]/20"
+        iconBorder="border-[var(--primary-dark)]/50"
+        iconColor="text-[var(--primary)]"
+        iconPath="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0z"
+        useGiB={settings.useGiBForAnon}
+        onToggleUnit={() => onChange({ useGiBForAnon: !settings.useGiBForAnon })}
+        maxUpload={settings.anoMaxUpload}
+        ipQuota={settings.anoIpQuota}
+        onChangeMax={(raw) => onChange({ anoMaxUpload: convertToMB(raw, settings.useGiBForAnon) })}
+        onChangeIp={(raw) => onChange({ anoIpQuota: convertToMB(raw, settings.useGiBForAnon) })}
+      />
+
+      <QuotaGroup
+        title={t("admin.quotas.section_authenticated")}
+        iconBg="bg-[var(--secondary)]/20"
+        iconBorder="border-[var(--secondary-dark)]/50"
+        iconColor="text-[var(--secondary)]"
+        iconPath="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        useGiB={settings.useGiBForAuth}
+        onToggleUnit={() => onChange({ useGiBForAuth: !settings.useGiBForAuth })}
+        maxUpload={settings.authMaxUpload}
+        ipQuota={settings.authIpQuota}
+        onChangeMax={(raw) => onChange({ authMaxUpload: convertToMB(raw, settings.useGiBForAuth) })}
+        onChangeIp={(raw) => onChange({ authIpQuota: convertToMB(raw, settings.useGiBForAuth) })}
+      />
+
+      <div className="p-4 bg-[var(--primary)]/10 border border-[var(--primary-dark)]/30 rounded-lg text-[var(--primary-hover)] text-sm">
+        <p className="font-medium mb-2">💡 Info</p>
+        <ul className="space-y-1 text-xs">
+          <li>• {t("admin.quotas.max_file_size_hint")}</li>
+          <li>• {t("admin.quotas.ip_quota_hint")}</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/S3StorageSection.tsx
+++ b/src/components/admin/S3StorageSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FieldInput, Toggle } from "./settings/primitives";
 
 export interface S3SectionSettings {
   s3Enabled: boolean;
@@ -16,61 +17,6 @@ interface Props {
   settings: S3SectionSettings;
   onChange: (patch: Partial<S3SectionSettings>) => void;
 }
-
-// ---------------------------------------------------------------------------
-// Local UI primitives
-// ---------------------------------------------------------------------------
-
-interface ToggleProps {
-  checked: boolean;
-  onChange: () => void;
-}
-
-function Toggle({ checked, onChange }: ToggleProps) {
-  return (
-    <button
-      onClick={onChange}
-      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors cursor-pointer ${
-        checked ? "bg-[var(--primary)]" : "bg-gray-600"
-      }`}
-    >
-      <span
-        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
-          checked ? "translate-x-7" : "translate-x-1"
-        }`}
-      />
-    </button>
-  );
-}
-
-interface FieldInputProps {
-  label: string;
-  type?: "text" | "password";
-  value: string;
-  onChange: (value: string | null) => void;
-  placeholder?: string;
-  hint?: string;
-}
-
-function FieldInput({ label, type = "text", value, onChange, placeholder, hint }: FieldInputProps) {
-  return (
-    <div>
-      <label className="text-sm font-medium text-[var(--foreground)]">{label}</label>
-      <input
-        type={type}
-        value={value}
-        onChange={(e) => onChange(e.target.value || null)}
-        placeholder={placeholder}
-        className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
-      />
-      {hint && <p className="text-xs text-[var(--foreground-muted)] mt-1">{hint}</p>}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Controlled section — no own state, no save button
-// ---------------------------------------------------------------------------
 
 export default function S3StorageSection({ settings, onChange }: Props) {
   const { t } = useTranslation();

--- a/src/components/admin/SettingsTab.tsx
+++ b/src/components/admin/SettingsTab.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState, useEffect, useCallback, type ReactNode } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import WaveSkeleton from "@/components/ui/WaveSkeleton";
 import SkeletonTransition from "@/components/ui/SkeletonTransition";
 import MDEditor from "@uiw/react-md-editor";
 import { Snackbar, Alert } from "@mui/material";
-import { convertFromMB, convertToMB } from "@/lib/formatSize";
 import WarningModal from "./WarningModal";
+import GeneralSection from "./GeneralSection";
+import CaptchaSection from "./CaptchaSection";
+import SmtpSection from "./SmtpSection";
+import QuotasSection from "./QuotasSection";
 import S3StorageSection from "./S3StorageSection";
 
 interface Settings {
@@ -25,12 +28,10 @@ interface Settings {
   useGiBForAuth: boolean;
   termsOfUses: string;
   allowIframeEmbedding: boolean;
-  // CAPTCHA
   captchaEnabled: boolean;
   captchaProvider: string | null;
   captchaSiteKey: string | null;
   captchaSecretKey: string | null;
-  // SMTP / Email Verification
   smtpEnabled: boolean;
   smtpHost: string | null;
   smtpPort: number | null;
@@ -39,7 +40,6 @@ interface Settings {
   smtpFrom: string | null;
   smtpSecure: boolean;
   emailVerificationRequired: boolean;
-  // S3 Storage
   s3Enabled: boolean;
   s3Endpoint: string | null;
   s3Region: string | null;
@@ -47,124 +47,6 @@ interface Settings {
   s3AccessKeyId: string | null;
   s3SecretAccessKey: string | null;
 }
-
-// ---------------------------------------------------------------------------
-// Sub-components (not exported)
-// ---------------------------------------------------------------------------
-
-interface ToggleProps {
-  checked: boolean;
-  onChange: () => void;
-  activeColor?: string;
-  disabled?: boolean;
-}
-
-function Toggle({ checked, onChange, activeColor = "bg-[var(--primary)]", disabled }: ToggleProps) {
-  return (
-    <button
-      disabled={disabled}
-      onClick={onChange}
-      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors ${
-        checked ? activeColor : "bg-gray-600"
-      }${disabled ? " opacity-50 cursor-not-allowed" : " cursor-pointer"}`}
-    >
-      <span
-        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
-          checked ? "translate-x-7" : "translate-x-1"
-        }`}
-      />
-    </button>
-  );
-}
-
-interface ToggleRowProps {
-  label: ReactNode;
-  description?: ReactNode;
-  extra?: ReactNode;
-  checked: boolean;
-  onChange: () => void;
-  disabled?: boolean;
-  activeColor?: string;
-}
-
-function ToggleRow({
-  label,
-  description,
-  extra,
-  checked,
-  onChange,
-  disabled,
-  activeColor,
-}: ToggleRowProps) {
-  return (
-    <div className="flex items-center justify-between p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
-      <div>
-        <label className="text-[var(--foreground)] font-medium">{label}</label>
-        {description && (
-          <p className="text-sm text-[var(--foreground-muted)] mt-1">{description}</p>
-        )}
-        {extra}
-      </div>
-      <Toggle checked={checked} onChange={onChange} disabled={disabled} activeColor={activeColor} />
-    </div>
-  );
-}
-
-interface QuotaInputProps {
-  label: string;
-  hint: string;
-  value: number;
-  onChange: (raw: number) => void;
-  unit: string;
-  currentValueLabel: string;
-}
-
-function QuotaInput({ label, hint, value, onChange, unit, currentValueLabel }: QuotaInputProps) {
-  return (
-    <div>
-      <label className="text-sm text-[var(--foreground)]">{label}</label>
-      <p className="text-xs text-[var(--foreground-muted)] mb-2">{hint}</p>
-      <div className="flex items-center gap-3">
-        <div className="flex-1">
-          <input
-            type="number"
-            value={value}
-            onChange={(e) => onChange(parseInt(e.target.value))}
-            className="w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
-            min="0"
-          />
-        </div>
-        <span className="text-sm text-[var(--foreground-muted)] whitespace-nowrap">{unit}</span>
-      </div>
-      <p className="text-xs text-[var(--foreground-muted)] mt-1">{currentValueLabel}</p>
-    </div>
-  );
-}
-
-interface SettingsInputProps {
-  type: "text" | "password" | "number";
-  value: string | number;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  placeholder?: string;
-  min?: number;
-}
-
-function SettingsInput({ type, value, onChange, placeholder, min }: SettingsInputProps) {
-  return (
-    <input
-      type={type}
-      value={value}
-      onChange={onChange}
-      placeholder={placeholder}
-      min={min}
-      className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
 
 export default function SettingsTab() {
   const { t } = useTranslation();
@@ -184,7 +66,6 @@ export default function SettingsTab() {
       if (!response.ok) throw new Error("Failed to fetch settings");
       const data = await response.json();
       setHasActiveSSO(data.hasActiveSSO);
-      // Ensure all boolean fields have default values
       setSettings({
         ...data.settings,
         allowSignin: data.settings.allowSignin ?? true,
@@ -226,89 +107,17 @@ export default function SettingsTab() {
     fetchSettings();
   }, [fetchSettings]);
 
-  // Force allowSignin to true when disableCredentialsLogin is true
-  useEffect(() => {
-    if (!settings?.disableCredentialsLogin) {
-      return;
-    }
-
-    setSettings((prev) => {
-      if (!prev || !prev.disableCredentialsLogin || prev.allowSignin) {
-        return prev;
-      }
-      return {
-        ...prev,
-        allowSignin: true,
-      };
-    });
-  }, [settings?.disableCredentialsLogin]);
-
-  const handleToggle = (key: keyof Settings) => {
-    if (settings && typeof settings[key] === "boolean") {
-      // Special handling for disableCredentialsLogin - show warning modal
-      if (key === "disableCredentialsLogin" && !settings.disableCredentialsLogin) {
-        setShowWarningModal(true);
-        return;
-      }
-
-      setSettings({
-        ...settings,
-        [key]: !settings[key],
-      });
-    }
-  };
+  const patchSettings = useCallback((patch: Partial<Settings>) => {
+    setSettings((prev) => (prev ? { ...prev, ...patch } : prev));
+  }, []);
 
   const handleConfirmDisableCredentials = () => {
-    if (settings) {
-      setSettings({
-        ...settings,
-        disableCredentialsLogin: true,
-        allowSignin: true, // Force allowSignin to true when enabling SSO-only
-      });
-    }
+    patchSettings({ disableCredentialsLogin: true, allowSignin: true });
     setShowWarningModal(false);
-  };
-
-  const handleCancelDisableCredentials = () => {
-    setShowWarningModal(false);
-  };
-
-  const handleChange = (key: keyof Settings, value: number) => {
-    if (settings) {
-      setSettings({
-        ...settings,
-        [key]: value,
-      });
-    }
-  };
-
-  const handleUnitToggle = (key: "useGiBForAnon" | "useGiBForAuth") => {
-    if (settings) {
-      // Simply toggle the unit preference - values stay in MB internally
-      setSettings({
-        ...settings,
-        [key]: !settings[key],
-      });
-    }
-  };
-
-  const handleTextChange = (key: keyof Settings, value: string | null) => {
-    if (settings) {
-      setSettings({ ...settings, [key]: value });
-    }
   };
 
   const handleMarkdownChange = (value: string | undefined) => {
-    if (settings) {
-      setSettings({
-        ...settings,
-        termsOfUses: value || "",
-      });
-    }
-  };
-
-  const handleToastClose = () => {
-    setToastOpen(false);
+    patchSettings({ termsOfUses: value || "" });
   };
 
   const handleSave = async () => {
@@ -369,257 +178,33 @@ export default function SettingsTab() {
     <SkeletonTransition loading={loading} skeleton={skeleton} className="w-full">
       {settings && (
         <div className="space-y-6 w-full">
-          {/* Warning Modal */}
           <WarningModal
             open={showWarningModal}
             title={t("admin.settings.warning_disable_credentials_title")}
             message={t("admin.settings.warning_disable_credentials_message")}
             onConfirm={handleConfirmDisableCredentials}
-            onCancel={handleCancelDisableCredentials}
+            onCancel={() => setShowWarningModal(false)}
           />
 
-          {/* Toast Notifications */}
-          <Snackbar open={toastOpen} autoHideDuration={3000} onClose={handleToastClose}>
-            <Alert onClose={handleToastClose} severity={toastSeverity} sx={{ width: "100%" }}>
+          <Snackbar open={toastOpen} autoHideDuration={3000} onClose={() => setToastOpen(false)}>
+            <Alert
+              onClose={() => setToastOpen(false)}
+              severity={toastSeverity}
+              sx={{ width: "100%" }}
+            >
               {toastMessage}
             </Alert>
           </Snackbar>
 
-          {/* General Settings */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-[var(--foreground)]">
-              {t("admin.settings.section_general")}
-            </h3>
+          <GeneralSection
+            settings={settings}
+            hasActiveSSO={hasActiveSSO}
+            onChange={patchSettings}
+            onRequestDisableCredentials={() => setShowWarningModal(true)}
+          />
 
-            <ToggleRow
-              label={t("admin.settings.disable_credentials_login")}
-              description={t("admin.settings.disable_credentials_login_desc")}
-              extra={
-                !hasActiveSSO && (
-                  <p className="text-xs text-red-400 mt-1">{t("admin.settings.no_sso_active")}</p>
-                )
-              }
-              checked={settings.disableCredentialsLogin}
-              onChange={() => handleToggle("disableCredentialsLogin")}
-              disabled={!hasActiveSSO}
-            />
+          <QuotasSection settings={settings} onChange={patchSettings} />
 
-            {!settings.disableCredentialsLogin && (
-              <ToggleRow
-                label={t("admin.settings.allow_signup")}
-                description={t("admin.settings.allow_signup_desc")}
-                checked={settings.allowSignin}
-                onChange={() => handleToggle("allowSignin")}
-              />
-            )}
-
-            <ToggleRow
-              label={t("admin.settings.allow_anon_fileshare")}
-              description={t("admin.settings.allow_anon_fileshare_desc")}
-              checked={settings.allowAnonFileShare}
-              onChange={() => handleToggle("allowAnonFileShare")}
-            />
-
-            <ToggleRow
-              label={t("admin.settings.allow_anon_linkshare")}
-              description={t("admin.settings.allow_anon_linkshare_desc")}
-              checked={settings.allowAnonLinkShare}
-              onChange={() => handleToggle("allowAnonLinkShare")}
-            />
-
-            <ToggleRow
-              label={t("admin.settings.allow_anon_pasteshare")}
-              description={t("admin.settings.allow_anon_pasteshare_desc")}
-              checked={settings.allowAnonPasteShare}
-              onChange={() => handleToggle("allowAnonPasteShare")}
-            />
-
-            <ToggleRow
-              label={t("admin.settings.allow_iframe_embedding")}
-              description={t("admin.settings.allow_iframe_embedding_desc")}
-              extra={
-                settings.allowIframeEmbedding && (
-                  <p className="text-xs text-yellow-400 mt-1">
-                    {t("admin.settings.allow_iframe_embedding_warning")}
-                  </p>
-                )
-              }
-              checked={settings.allowIframeEmbedding}
-              onChange={() => handleToggle("allowIframeEmbedding")}
-              activeColor="bg-yellow-500"
-            />
-          </div>
-
-          {/* Upload Quotas */}
-          <div className="space-y-4">
-            <div className="flex items-center gap-2 mb-4">
-              <div className="h-8 w-8 rounded-lg bg-[var(--primary)]/20 border border-[var(--primary-dark)]/50 flex items-center justify-center">
-                <svg
-                  className="w-4 h-4 text-[var(--primary)]"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="text-lg font-semibold text-[var(--foreground)]">
-                {t("admin.quotas.title")}
-              </h3>
-            </div>
-
-            {/* Anonymous Users */}
-            <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
-              <div className="flex items-center gap-2 mb-2 justify-between">
-                <div className="flex items-center gap-2">
-                  <div className="h-6 w-6 rounded-lg bg-[var(--primary)]/20 border border-[var(--primary-dark)]/50 flex items-center justify-center">
-                    <svg
-                      className="w-3 h-3 text-[var(--primary)]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0z"
-                      />
-                    </svg>
-                  </div>
-                  <label className="text-[var(--foreground)] font-medium">
-                    {t("admin.quotas.section_anonymous")}
-                  </label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <label className="text-sm text-[var(--foreground-muted)]">
-                    {t("admin.quotas.unit_format")}
-                  </label>
-                  <button
-                    onClick={() => handleUnitToggle("useGiBForAnon")}
-                    className={`px-3 py-1 rounded-lg font-medium transition-all ${
-                      settings.useGiBForAnon
-                        ? "bg-[var(--secondary)] text-white"
-                        : "bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)]"
-                    }`}
-                  >
-                    {settings.useGiBForAnon ? "GiB" : "MiB"}
-                  </button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <QuotaInput
-                  label={t("admin.quotas.max_file_size")}
-                  hint={t("admin.quotas.max_file_size_hint")}
-                  value={convertFromMB(settings.anoMaxUpload, settings.useGiBForAnon)}
-                  onChange={(raw) =>
-                    handleChange("anoMaxUpload", convertToMB(raw, settings.useGiBForAnon))
-                  }
-                  unit={settings.useGiBForAnon ? "GiB" : "MiB"}
-                  currentValueLabel={t("admin.quotas.current_value", {
-                    value: convertFromMB(settings.anoMaxUpload, settings.useGiBForAnon),
-                  })}
-                />
-                <QuotaInput
-                  label={t("admin.quotas.ip_quota")}
-                  hint={t("admin.quotas.ip_quota_hint")}
-                  value={convertFromMB(settings.anoIpQuota, settings.useGiBForAnon)}
-                  onChange={(raw) =>
-                    handleChange("anoIpQuota", convertToMB(raw, settings.useGiBForAnon))
-                  }
-                  unit={settings.useGiBForAnon ? "GiB" : "MiB"}
-                  currentValueLabel={t("admin.quotas.current_value", {
-                    value: convertFromMB(settings.anoIpQuota, settings.useGiBForAnon),
-                  })}
-                />
-              </div>
-            </div>
-
-            {/* Authenticated Users */}
-            <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
-              <div className="flex items-center gap-2 mb-2 justify-between">
-                <div className="flex items-center gap-2">
-                  <div className="h-6 w-6 rounded-lg bg-[var(--secondary)]/20 border border-[var(--secondary-dark)]/50 flex items-center justify-center">
-                    <svg
-                      className="w-3 h-3 text-[var(--secondary)]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                  </div>
-                  <label className="text-[var(--foreground)] font-medium">
-                    {t("admin.quotas.section_authenticated")}
-                  </label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <label className="text-sm text-[var(--foreground-muted)]">
-                    {t("admin.quotas.unit_format")}
-                  </label>
-                  <button
-                    onClick={() => handleUnitToggle("useGiBForAuth")}
-                    className={`px-3 py-1 rounded-lg font-medium transition-all ${
-                      settings.useGiBForAuth
-                        ? "bg-[var(--secondary)] text-white"
-                        : "bg-[var(--surface)] border border-[var(--border)] text-[var(--foreground)]"
-                    }`}
-                  >
-                    {settings.useGiBForAuth ? "GiB" : "MiB"}
-                  </button>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <QuotaInput
-                  label={t("admin.quotas.max_file_size")}
-                  hint={t("admin.quotas.max_file_size_hint")}
-                  value={convertFromMB(settings.authMaxUpload, settings.useGiBForAuth)}
-                  onChange={(raw) =>
-                    handleChange("authMaxUpload", convertToMB(raw, settings.useGiBForAuth))
-                  }
-                  unit={settings.useGiBForAuth ? "GiB" : "MiB"}
-                  currentValueLabel={t("admin.quotas.current_value", {
-                    value: convertFromMB(settings.authMaxUpload, settings.useGiBForAuth),
-                  })}
-                />
-                <QuotaInput
-                  label={t("admin.quotas.ip_quota")}
-                  hint={t("admin.quotas.ip_quota_hint")}
-                  value={convertFromMB(settings.authIpQuota, settings.useGiBForAuth)}
-                  onChange={(raw) =>
-                    handleChange("authIpQuota", convertToMB(raw, settings.useGiBForAuth))
-                  }
-                  unit={settings.useGiBForAuth ? "GiB" : "MiB"}
-                  currentValueLabel={t("admin.quotas.current_value", {
-                    value: convertFromMB(settings.authIpQuota, settings.useGiBForAuth),
-                  })}
-                />
-              </div>
-            </div>
-          </div>
-
-          {/* Info Box */}
-          <div className="p-4 bg-[var(--primary)]/10 border border-[var(--primary-dark)]/30 rounded-lg text-[var(--primary-hover)] text-sm">
-            <p className="font-medium mb-2">💡 Info</p>
-            <ul className="space-y-1 text-xs">
-              <li>• {t("admin.quotas.max_file_size_hint")}</li>
-              <li>• {t("admin.quotas.ip_quota_hint")}</li>
-            </ul>
-          </div>
-
-          {/* Markdown Editor for Terms of Use */}
           <div className="space-y-4">
             <h3 className="text-lg font-semibold text-[var(--foreground)]">
               {t("footer.terms_of_use")}
@@ -631,185 +216,12 @@ export default function SettingsTab() {
             />
           </div>
 
-          {/* CAPTCHA Settings */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-[var(--foreground)]">
-              {t("admin.settings.section_captcha")}
-            </h3>
+          <CaptchaSection settings={settings} onChange={patchSettings} />
 
-            <ToggleRow
-              label={t("admin.settings.captcha_enabled")}
-              description={t("admin.settings.captcha_enabled_desc")}
-              checked={settings.captchaEnabled}
-              onChange={() => handleToggle("captchaEnabled")}
-            />
+          <SmtpSection settings={settings} onChange={patchSettings} />
 
-            {settings.captchaEnabled && (
-              <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
-                <div>
-                  <label className="text-sm font-medium text-[var(--foreground)]">
-                    {t("admin.settings.captcha_provider")}
-                  </label>
-                  <select
-                    value={settings.captchaProvider ?? ""}
-                    onChange={(e) => handleTextChange("captchaProvider", e.target.value || null)}
-                    className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
-                  >
-                    <option value="">{t("admin.settings.captcha_provider_select")}</option>
-                    <option value="recaptcha">Google reCAPTCHA v2</option>
-                    <option value="turnstile">Cloudflare Turnstile</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="text-sm font-medium text-[var(--foreground)]">
-                    {t("admin.settings.captcha_site_key")}
-                  </label>
-                  <SettingsInput
-                    type="text"
-                    value={settings.captchaSiteKey ?? ""}
-                    onChange={(e) => handleTextChange("captchaSiteKey", e.target.value || null)}
-                    placeholder={t("admin.settings.captcha_site_key_placeholder") as string}
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium text-[var(--foreground)]">
-                    {t("admin.settings.captcha_secret_key")}
-                  </label>
-                  <SettingsInput
-                    type="password"
-                    value={settings.captchaSecretKey ?? ""}
-                    onChange={(e) => handleTextChange("captchaSecretKey", e.target.value || null)}
-                    placeholder={t("admin.settings.captcha_secret_key_placeholder") as string}
-                  />
-                  <p className="text-xs text-[var(--foreground-muted)] mt-1">
-                    {t("admin.settings.captcha_secret_key_hint")}
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
+          <S3StorageSection settings={settings} onChange={patchSettings} />
 
-          {/* SMTP / Email Verification Settings */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold text-[var(--foreground)]">
-              {t("admin.settings.section_smtp")}
-            </h3>
-
-            <ToggleRow
-              label={t("admin.settings.smtp_enabled")}
-              description={t("admin.settings.smtp_enabled_desc")}
-              checked={settings.smtpEnabled}
-              onChange={() => handleToggle("smtpEnabled")}
-            />
-
-            {settings.smtpEnabled && (
-              <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium text-[var(--foreground)]">
-                      {t("admin.settings.smtp_host")}
-                    </label>
-                    <SettingsInput
-                      type="text"
-                      value={settings.smtpHost ?? ""}
-                      onChange={(e) => handleTextChange("smtpHost", e.target.value || null)}
-                      placeholder="smtp.example.com"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-sm font-medium text-[var(--foreground)]">
-                      {t("admin.settings.smtp_port")}
-                    </label>
-                    <SettingsInput
-                      type="number"
-                      value={settings.smtpPort ?? 587}
-                      onChange={(e) => handleChange("smtpPort", parseInt(e.target.value) || 587)}
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium text-[var(--foreground)]">
-                      {t("admin.settings.smtp_user")}
-                    </label>
-                    <SettingsInput
-                      type="text"
-                      value={settings.smtpUser ?? ""}
-                      onChange={(e) => handleTextChange("smtpUser", e.target.value || null)}
-                      placeholder="user@example.com"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-sm font-medium text-[var(--foreground)]">
-                      {t("admin.settings.smtp_password")}
-                    </label>
-                    <SettingsInput
-                      type="password"
-                      value={settings.smtpPassword ?? ""}
-                      onChange={(e) => handleTextChange("smtpPassword", e.target.value || null)}
-                      placeholder={t("admin.settings.smtp_password_placeholder") as string}
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium text-[var(--foreground)]">
-                      {t("admin.settings.smtp_from")}
-                    </label>
-                    <SettingsInput
-                      type="text"
-                      value={settings.smtpFrom ?? ""}
-                      onChange={(e) => handleTextChange("smtpFrom", e.target.value || null)}
-                      placeholder="noreply@example.com"
-                    />
-                    <p className="text-xs text-[var(--foreground-muted)] mt-1">
-                      {t("admin.settings.smtp_from_hint")}
-                    </p>
-                  </div>
-                  <div className="flex items-center justify-between mt-6">
-                    <div>
-                      <label className="text-sm font-medium text-[var(--foreground)]">
-                        {t("admin.settings.smtp_secure")}
-                      </label>
-                      <p className="text-xs text-[var(--foreground-muted)] mt-1">
-                        {t("admin.settings.smtp_secure_hint")}
-                      </p>
-                    </div>
-                    <Toggle
-                      checked={settings.smtpSecure}
-                      onChange={() => handleToggle("smtpSecure")}
-                    />
-                  </div>
-                </div>
-
-                <div className="pt-2 border-t border-[var(--border)]/30">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <label className="text-[var(--foreground)] font-medium">
-                        {t("admin.settings.email_verification_required")}
-                      </label>
-                      <p className="text-sm text-[var(--foreground-muted)] mt-1">
-                        {t("admin.settings.email_verification_required_desc")}
-                      </p>
-                    </div>
-                    <Toggle
-                      checked={settings.emailVerificationRequired}
-                      onChange={() => handleToggle("emailVerificationRequired")}
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* S3 Storage */}
-          {/* See issue #261: refactor General/CAPTCHA/SMTP/Quotas sections into controlled components */}
-          <S3StorageSection
-            settings={settings}
-            onChange={(patch) => setSettings((prev) => (prev ? { ...prev, ...patch } : prev))}
-          />
-
-          {/* Save Button */}
           <div className="flex justify-end">
             <button
               onClick={handleSave}

--- a/src/components/admin/SmtpSection.tsx
+++ b/src/components/admin/SmtpSection.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { FieldInput, Toggle, ToggleRow } from "./settings/primitives";
+
+export interface SmtpSectionSettings {
+  smtpEnabled: boolean;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpUser: string | null;
+  smtpPassword: string | null;
+  smtpFrom: string | null;
+  smtpSecure: boolean;
+  emailVerificationRequired: boolean;
+}
+
+interface Props {
+  settings: SmtpSectionSettings;
+  onChange: (patch: Partial<SmtpSectionSettings>) => void;
+}
+
+export default function SmtpSection({ settings, onChange }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-[var(--foreground)]">
+        {t("admin.settings.section_smtp")}
+      </h3>
+
+      <ToggleRow
+        label={t("admin.settings.smtp_enabled")}
+        description={t("admin.settings.smtp_enabled_desc")}
+        checked={settings.smtpEnabled}
+        onChange={() => onChange({ smtpEnabled: !settings.smtpEnabled })}
+      />
+
+      {settings.smtpEnabled && (
+        <div className="space-y-3 p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <FieldInput
+              label={t("admin.settings.smtp_host")}
+              value={settings.smtpHost ?? ""}
+              onChange={(v) => onChange({ smtpHost: v })}
+              placeholder="smtp.example.com"
+            />
+            <FieldInput
+              label={t("admin.settings.smtp_port")}
+              type="number"
+              value={settings.smtpPort ?? 587}
+              onChange={(v) => onChange({ smtpPort: v ? parseInt(v) : 587 })}
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <FieldInput
+              label={t("admin.settings.smtp_user")}
+              value={settings.smtpUser ?? ""}
+              onChange={(v) => onChange({ smtpUser: v })}
+              placeholder="user@example.com"
+            />
+            <FieldInput
+              label={t("admin.settings.smtp_password")}
+              type="password"
+              value={settings.smtpPassword ?? ""}
+              onChange={(v) => onChange({ smtpPassword: v })}
+              placeholder={t("admin.settings.smtp_password_placeholder") as string}
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <FieldInput
+              label={t("admin.settings.smtp_from")}
+              value={settings.smtpFrom ?? ""}
+              onChange={(v) => onChange({ smtpFrom: v })}
+              placeholder="noreply@example.com"
+              hint={t("admin.settings.smtp_from_hint") as string}
+            />
+            <div className="flex items-center justify-between mt-6">
+              <div>
+                <label className="text-sm font-medium text-[var(--foreground)]">
+                  {t("admin.settings.smtp_secure")}
+                </label>
+                <p className="text-xs text-[var(--foreground-muted)] mt-1">
+                  {t("admin.settings.smtp_secure_hint")}
+                </p>
+              </div>
+              <Toggle
+                checked={settings.smtpSecure}
+                onChange={() => onChange({ smtpSecure: !settings.smtpSecure })}
+              />
+            </div>
+          </div>
+
+          <div className="pt-2 border-t border-[var(--border)]/30">
+            <div className="flex items-center justify-between">
+              <div>
+                <label className="text-[var(--foreground)] font-medium">
+                  {t("admin.settings.email_verification_required")}
+                </label>
+                <p className="text-sm text-[var(--foreground-muted)] mt-1">
+                  {t("admin.settings.email_verification_required_desc")}
+                </p>
+              </div>
+              <Toggle
+                checked={settings.emailVerificationRequired}
+                onChange={() =>
+                  onChange({ emailVerificationRequired: !settings.emailVerificationRequired })
+                }
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/settings/primitives.tsx
+++ b/src/components/admin/settings/primitives.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+interface ToggleProps {
+  checked: boolean;
+  onChange: () => void;
+  activeColor?: string;
+  disabled?: boolean;
+}
+
+export function Toggle({
+  checked,
+  onChange,
+  activeColor = "bg-[var(--primary)]",
+  disabled,
+}: ToggleProps) {
+  return (
+    <button
+      disabled={disabled}
+      onClick={onChange}
+      className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors ${
+        checked ? activeColor : "bg-gray-600"
+      }${disabled ? " opacity-50 cursor-not-allowed" : " cursor-pointer"}`}
+    >
+      <span
+        className={`inline-block h-6 w-6 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-7" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+interface ToggleRowProps {
+  label: ReactNode;
+  description?: ReactNode;
+  extra?: ReactNode;
+  checked: boolean;
+  onChange: () => void;
+  disabled?: boolean;
+  activeColor?: string;
+}
+
+export function ToggleRow({
+  label,
+  description,
+  extra,
+  checked,
+  onChange,
+  disabled,
+  activeColor,
+}: ToggleRowProps) {
+  return (
+    <div className="flex items-center justify-between p-4 bg-[var(--surface)]/20 rounded-lg border border-[var(--border)]/50">
+      <div>
+        <label className="text-[var(--foreground)] font-medium">{label}</label>
+        {description && (
+          <p className="text-sm text-[var(--foreground-muted)] mt-1">{description}</p>
+        )}
+        {extra}
+      </div>
+      <Toggle checked={checked} onChange={onChange} disabled={disabled} activeColor={activeColor} />
+    </div>
+  );
+}
+
+interface FieldInputProps {
+  label: string;
+  type?: "text" | "password" | "number";
+  value: string | number;
+  onChange: (value: string | null) => void;
+  placeholder?: string;
+  hint?: string;
+  min?: number;
+}
+
+export function FieldInput({
+  label,
+  type = "text",
+  value,
+  onChange,
+  placeholder,
+  hint,
+  min,
+}: FieldInputProps) {
+  return (
+    <div>
+      <label className="text-sm font-medium text-[var(--foreground)]">{label}</label>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value || null)}
+        placeholder={placeholder}
+        min={min}
+        className="mt-1 w-full px-3 py-2 bg-[var(--surface)]/50 border border-[var(--border)]/50 rounded-lg text-[var(--foreground)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+      />
+      {hint && <p className="text-xs text-[var(--foreground-muted)] mt-1">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/filePreview/PdfViewer.tsx
+++ b/src/components/filePreview/PdfViewer.tsx
@@ -6,10 +6,7 @@ import { useTranslation } from "react-i18next";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  "react-pdf/node_modules/pdfjs-dist/build/pdf.worker.min.mjs",
-  import.meta.url
-).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
 interface PdfViewerProps {
   fileUrl: string;

--- a/src/components/filePreview/PdfViewer.tsx
+++ b/src/components/filePreview/PdfViewer.tsx
@@ -6,8 +6,10 @@ import { useTranslation } from "react-i18next";
 import "react-pdf/dist/Page/AnnotationLayer.css";
 import "react-pdf/dist/Page/TextLayer.css";
 
-// Configure PDF.js worker
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  "react-pdf/node_modules/pdfjs-dist/build/pdf.worker.min.mjs",
+  import.meta.url
+).toString();
 
 interface PdfViewerProps {
   fileUrl: string;

--- a/src/components/shareComponents/ShareSuccess.tsx
+++ b/src/components/shareComponents/ShareSuccess.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { QRCodeSVG } from "qrcode.react";
 import { useFetch } from "@/hooks/useFetch";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ const SCALAR_DOMAINS =
 // Helper function to add security headers
 function addSecurityHeaders(
   response: NextResponse,
-  isApiDocs = false,
+  _isApiDocs = false,
   isScalarHtml = false,
   allowIframeEmbedding = false
 ): NextResponse {


### PR DESCRIPTION
Closes #261

## Summary
- Extract General, CAPTCHA, SMTP and Quotas sections from `SettingsTab` into dedicated controlled components, mirroring the existing `S3StorageSection` pattern (state owned by `SettingsTab`, single save button).
- Add shared UI primitives (`Toggle`, `ToggleRow`, `FieldInput`) under `src/components/admin/settings/` to avoid duplication across sections.
- Refactor `S3StorageSection` to reuse the shared primitives.
- Fix `PdfViewer` worker source: resolve locally from `react-pdf`'s nested `pdfjs-dist` to fix version mismatch and mixed-content errors.
- Clean up unused vars/imports flagged by ESLint (8 warnings → 0).