### PR TITLE
fix(fileshare): show error instead of success when server returns 500

### DIFF
--- a/src/components/FileShare.tsx
+++ b/src/components/FileShare.tsx
@@ -350,13 +350,14 @@ const FileShare: React.FC = () => {
             }
           },
           onSuccess: () => {
-            if (shareSlug) {
-              setSuccess(`${window.location.origin}/f/${shareSlug}`);
-              setSuccessSlug(shareSlug);
-            } else {
-              setSuccess(t("fileshare.success_title", "File shared successfully!"));
+            if (!shareSlug) {
+              setError(t("fileshare.network_error", "Network error — could not create share"));
+              setLoading(false);
+              setUploadProgress(0);
+              return;
             }
-
+            setSuccess(`${window.location.origin}/f/${shareSlug}`);
+            setSuccessSlug(shareSlug);
             setFiles([]);
             setSlug("");
             setPassword("");
@@ -440,6 +441,8 @@ const FileShare: React.FC = () => {
             bytesUploadedSoFar += files[i].file.size;
           }
 
+          let fileProcessed = false;
+
           const upload = new tus.Upload(file, {
             endpoint: "/api/tus",
             retryDelays: [0, 1000, 3000, 5000, 10000],
@@ -488,12 +491,21 @@ const FileShare: React.FC = () => {
               const idHeader = res.getHeader("X-Share-Id");
               if (slugHeader) {
                 shareSlug = slugHeader;
+                fileProcessed = true;
               }
               if (idHeader) {
                 shareId = idHeader;
               }
             },
             onSuccess: () => {
+              if (!fileProcessed) {
+                setError(
+                  `${t("fileshare.file", "File")} ${index + 1}: ${t("fileshare.network_error", "Network error — could not create share")}`
+                );
+                setLoading(false);
+                setUploadProgress(0);
+                return;
+              }
               uploadNextFile(index + 1);
             },
           });


### PR DESCRIPTION
## Summary

- When `onUploadFinish` fails with a 500 error, tus bytes are already stored server-side. On retry, tus-js-client detects `offset == total` and calls `onSuccess` directly without re-triggering `onUploadFinish`, so no `X-Share-Slug` header is returned.
- Previously, `onSuccess` would fall back to a generic "File shared successfully!" message even though the share was never created in the database.
- Now `onSuccess` treats a missing `X-Share-Slug` as an error condition and displays an error message instead.
- For bulk uploads, a per-file `fileProcessed` flag (set only when `X-Share-Slug` is received in `onAfterResponse`) ensures each file's server-side processing is confirmed before continuing to the next file.