### PR TITLE
feat: add user default tab preference

### DIFF
--- a/prisma/migrations/20260526000000_add_user_default_tab/migration.sql
+++ b/prisma/migrations/20260526000000_add_user_default_tab/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+DO $$ BEGIN
+    CREATE TYPE "DefaultTab" AS ENUM ('linkshare', 'pasteshare', 'fileshare');
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "defaultTab" "DefaultTab" NOT NULL DEFAULT 'linkshare';


### PR DESCRIPTION
## Description

Adds a `defaultTab` preference to the `User` model, allowing users to set their preferred sharing tab (LinkShare, PasteShare, or FileShare) as their default view. This migration creates a new `DefaultTab` enum with three values and adds the column to the User table with 'linkshare' as the default.

## Type of Change

- [x] ✨ **New feature** (non-breaking change which adds functionality)

## Related Issues

Closes #269 

## Checklist

### Code Quality

- [x] Migration follows Prisma best practices (idempotent enum creation, IF NOT EXISTS for column)
- [x] Enum values align with existing share type naming conventions

### Database

- [x] Migration is backward compatible (uses IF NOT EXISTS, provides sensible default)
- [x] Enum creation handles duplicate object exceptions gracefully