### PR TITLE
navigation: add keyboard shortcuts for tabs and paste creation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
           pasteInitialCodeRef.current = text;
           setPasteInitialCode(text);
           setActiveTab("pasteshare");
-        }).catch((err) => { console.error("Failed to read clipboard:", err); });
+        }).catch((err) => { console.error("Failed to read clipboard:", err); throw err; });
       }
     };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,10 +9,12 @@ import FileShare from "@/components/FileShare";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "next-auth/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState("linkshare");
+  const [pasteInitialCode, setPasteInitialCode] = useState<string | undefined>(undefined);
+  const pasteInitialCodeRef = useRef<string | undefined>(undefined);
   const { t } = useTranslation();
   const { branding } = useTheme();
   const { status } = useSession();
@@ -20,6 +22,43 @@ export default function Home() {
   useEffect(() => {
     const saved = localStorage.getItem("defaultTab");
     if (saved) setActiveTab(saved);
+  }, []);
+
+  useEffect(() => {
+    const isInputFocused = () => {
+      const el = document.activeElement;
+      if (!el) return false;
+      const tag = el.tagName.toLowerCase();
+      return (
+        tag === "input" ||
+        tag === "textarea" ||
+        tag === "select" ||
+        (el as HTMLElement).isContentEditable
+      );
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Alt+1/2/3 → switch tabs
+      if (e.altKey && !e.ctrlKey && !e.metaKey) {
+        if (e.key === "1") { e.preventDefault(); setActiveTab("linkshare"); return; }
+        if (e.key === "2") { e.preventDefault(); setActiveTab("pasteshare"); return; }
+        if (e.key === "3") { e.preventDefault(); setActiveTab("fileshare"); return; }
+      }
+
+      // Ctrl+V (or Cmd+V) when not in an input → paste clipboard text into PasteShare
+      if ((e.ctrlKey || e.metaKey) && e.key === "v" && !isInputFocused()) {
+        e.preventDefault();
+        navigator.clipboard.readText().then((text) => {
+          if (!text.trim()) return;
+          pasteInitialCodeRef.current = text;
+          setPasteInitialCode(text);
+          setActiveTab("pasteshare");
+        }).catch(() => {});
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   useEffect(() => {
@@ -62,7 +101,15 @@ export default function Home() {
         {/* Content */}
         <div key={activeTab} className="animate-fade-in-up">
           {activeTab === "linkshare" && <LinkShare />}
-          {activeTab === "pasteshare" && <PasteShare />}
+          {activeTab === "pasteshare" && (
+            <PasteShare
+              initialCode={pasteInitialCode}
+              onInitialCodeConsumed={() => {
+                setPasteInitialCode(undefined);
+                pasteInitialCodeRef.current = undefined;
+              }}
+            />
+          )}
           {activeTab === "fileshare" && <FileShare />}
         </div>
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,6 +47,7 @@ export default function Home() {
 
       // Ctrl+V (or Cmd+V) when not in an input → paste clipboard text into PasteShare
       if ((e.ctrlKey || e.metaKey) && e.key === "v" && !isInputFocused()) {
+        if (!navigator?.clipboard?.readText) return;
         e.preventDefault();
         navigator.clipboard.readText().then((text) => {
           if (!text.trim()) return;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
           pasteInitialCodeRef.current = text;
           setPasteInitialCode(text);
           setActiveTab("pasteshare");
-        }).catch(() => {});
+        }).catch((err) => { console.error("Failed to read clipboard:", err); });
       }
     };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,12 +9,12 @@ import FileShare from "@/components/FileShare";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@/hooks/useTheme";
 import { useSession } from "next-auth/react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState("linkshare");
   const [pasteInitialCode, setPasteInitialCode] = useState<string | undefined>(undefined);
-  const pasteInitialCodeRef = useRef<string | undefined>(undefined);
+  const [fileInitialFiles, setFileInitialFiles] = useState<File[] | undefined>(undefined);
   const { t } = useTranslation();
   const { branding } = useTheme();
   const { status } = useSession();
@@ -40,26 +40,56 @@ export default function Home() {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Alt+1/2/3 → switch tabs
       if (e.altKey && !e.ctrlKey && !e.metaKey) {
-        if (e.key === "1") { e.preventDefault(); setActiveTab("linkshare"); return; }
-        if (e.key === "2") { e.preventDefault(); setActiveTab("pasteshare"); return; }
-        if (e.key === "3") { e.preventDefault(); setActiveTab("fileshare"); return; }
-      }
-
-      // Ctrl+V (or Cmd+V) when not in an input → paste clipboard text into PasteShare
-      if ((e.ctrlKey || e.metaKey) && e.key === "v" && !isInputFocused()) {
-        if (!navigator?.clipboard?.readText) return;
-        e.preventDefault();
-        navigator.clipboard.readText().then((text) => {
-          if (!text.trim()) return;
-          pasteInitialCodeRef.current = text;
-          setPasteInitialCode(text);
+        if (e.key === "1") {
+          e.preventDefault();
+          setActiveTab("linkshare");
+          return;
+        }
+        if (e.key === "2") {
+          e.preventDefault();
           setActiveTab("pasteshare");
-        }).catch((err) => { console.error("Failed to read clipboard:", err); });
+          return;
+        }
+        if (e.key === "3") {
+          e.preventDefault();
+          setActiveTab("fileshare");
+          return;
+        }
       }
     };
 
+    // Ctrl+V (or Cmd+V) → the browser fires a "paste" event carrying the
+    // clipboard contents. Files go to FileShare, plain text to PasteShare.
+    const handlePaste = (e: ClipboardEvent) => {
+      const clipboard = e.clipboardData;
+      if (!clipboard) return;
+
+      // Files take priority — pasting an image/file into a text field is a no-op
+      // anyway, so we hijack it regardless of what is focused.
+      const files = Array.from(clipboard.files);
+      if (files.length > 0) {
+        e.preventDefault();
+        setFileInitialFiles(files);
+        setActiveTab("fileshare");
+        return;
+      }
+
+      // Plain text → PasteShare, but only when not editing an input/textarea so
+      // normal pasting into form fields keeps working.
+      if (isInputFocused()) return;
+      const text = clipboard.getData("text");
+      if (!text.trim()) return;
+      e.preventDefault();
+      setPasteInitialCode(text);
+      setActiveTab("pasteshare");
+    };
+
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    document.addEventListener("paste", handlePaste);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("paste", handlePaste);
+    };
   }, []);
 
   useEffect(() => {
@@ -105,13 +135,15 @@ export default function Home() {
           {activeTab === "pasteshare" && (
             <PasteShare
               initialCode={pasteInitialCode}
-              onInitialCodeConsumed={() => {
-                setPasteInitialCode(undefined);
-                pasteInitialCodeRef.current = undefined;
-              }}
+              onInitialCodeConsumed={() => setPasteInitialCode(undefined)}
             />
           )}
-          {activeTab === "fileshare" && <FileShare />}
+          {activeTab === "fileshare" && (
+            <FileShare
+              initialFiles={fileInitialFiles}
+              onInitialFilesConsumed={() => setFileInitialFiles(undefined)}
+            />
+          )}
         </div>
       </main>
       <Footer />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
           pasteInitialCodeRef.current = text;
           setPasteInitialCode(text);
           setActiveTab("pasteshare");
-        }).catch((err) => { console.error("Failed to read clipboard:", err); throw err; });
+        }).catch((err) => { console.error("Failed to read clipboard:", err); });
       }
     };
 

--- a/src/components/FileShare.tsx
+++ b/src/components/FileShare.tsx
@@ -22,7 +22,12 @@ interface FileWithPath {
   relativePath: string;
 }
 
-const FileShare: React.FC = () => {
+interface FileShareProps {
+  initialFiles?: File[];
+  onInitialFilesConsumed?: () => void;
+}
+
+const FileShare: React.FC<FileShareProps> = ({ initialFiles, onInitialFilesConsumed }) => {
   const { isAuthenticated } = useAuth();
   const { t } = useTranslation();
 
@@ -31,6 +36,16 @@ const FileShare: React.FC = () => {
 
   const [files, setFiles] = useState<FileWithPath[]>([]);
   const [dragOver, setDragOver] = useState(false);
+
+  // Load files pasted from the clipboard (Ctrl+V on the home page)
+  useEffect(() => {
+    if (initialFiles && initialFiles.length > 0) {
+      setFiles(initialFiles.map((file) => ({ file, relativePath: file.name })));
+      setError(null);
+      onInitialFilesConsumed?.();
+    }
+  }, [initialFiles, onInitialFilesConsumed]);
+
   const [expiresDays, setExpiresDays] = useState<number>(isAuthenticated ? 30 : MAX_DAYS_ANON);
   const [neverExpires, setNeverExpires] = useState(false);
   const [slug, setSlug] = useState("");

--- a/src/components/PasteShare.tsx
+++ b/src/components/PasteShare.tsx
@@ -9,7 +9,12 @@ import LockedShare from "./shareComponents/LockedShare";
 import PasteShareSkeleton from "./PasteShareSkeleton";
 import SkeletonTransition from "@/components/ui/SkeletonTransition";
 
-const PasteShare: React.FC = () => {
+interface PasteShareProps {
+  initialCode?: string;
+  onInitialCodeConsumed?: () => void;
+}
+
+const PasteShare: React.FC<PasteShareProps> = ({ initialCode, onInitialCodeConsumed }) => {
   const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
   const [code, setCode] = React.useState(`function helloWorld() {
@@ -17,6 +22,13 @@ const PasteShare: React.FC = () => {
   }`);
   const [language, setLanguage] = React.useState("javascript");
   const { allowAnonPasteShare, loading: settingsLoading } = useShareSettings();
+
+  React.useEffect(() => {
+    if (initialCode) {
+      setCode(initialCode);
+      onInitialCodeConsumed?.();
+    }
+  }, [initialCode, onInitialCodeConsumed]);
 
   const content =
     !isAuthenticated && allowAnonPasteShare === false ? (

--- a/src/components/pasteShareComponents/ManageCodeBlock.tsx
+++ b/src/components/pasteShareComponents/ManageCodeBlock.tsx
@@ -46,6 +46,18 @@ const ManageCodeBlock: React.FC<{
   const [success, setSuccess] = React.useState<string | null>(null);
   const [successSlug, setSuccessSlug] = React.useState<string>("");
 
+  React.useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && !loading && code.trim()) {
+        e.preventDefault();
+        const form = document.querySelector("form");
+        if (form) form.requestSubmit();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [loading, code]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
@@ -154,6 +166,20 @@ const ManageCodeBlock: React.FC<{
         submitText={t("pasteshare_ui.submit", "Create paste")}
         iconPath="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2v0M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"
       />
+
+      {!loading && code.trim() && (
+        <p className="text-xs text-[var(--foreground-muted)] text-center mt-2">
+          {t("pasteshare_ui.shortcut", "Tip:")}{" "}
+          <kbd className="px-1 py-0.5 bg-[var(--surface)] border border-[var(--border)] rounded text-xs">
+            Ctrl
+          </kbd>{" "}
+          +{" "}
+          <kbd className="px-1 py-0.5 bg-[var(--surface)] border border-[var(--border)] rounded text-xs">
+            Enter
+          </kbd>{" "}
+          {t("pasteshare_ui.shortcut_tail", "to create quickly")}
+        </p>
+      )}
     </form>
   );
 };

--- a/src/components/pasteShareComponents/ManageCodeBlock.tsx
+++ b/src/components/pasteShareComponents/ManageCodeBlock.tsx
@@ -34,6 +34,7 @@ const ManageCodeBlock: React.FC<{
 }> = ({ code, language, onLanguageChange }) => {
   const { t } = useTranslation();
   const { isAuthenticated } = useAuth();
+  const formRef = React.useRef<HTMLFormElement>(null);
 
   const [slug, setSlug] = React.useState("");
   const [expiresDays, setExpiresDays] = React.useState<number>(isAuthenticated ? 30 : 7);
@@ -50,8 +51,7 @@ const ManageCodeBlock: React.FC<{
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "Enter" && !loading && code.trim()) {
         e.preventDefault();
-        const form = document.querySelector("form");
-        if (form) form.requestSubmit();
+        if (formRef.current) formRef.current.requestSubmit();
       }
     };
     document.addEventListener("keydown", handleKeyDown);
@@ -102,7 +102,7 @@ const ManageCodeBlock: React.FC<{
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form ref={formRef} onSubmit={handleSubmit} className="space-y-6">
       {error && <ShareError error={error} translationPrefix="pasteshare_ui" />}
 
       {success && (

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -60,7 +60,9 @@
     "view_limit_desc": "Der Paste läuft nach einer festgelegten Anzahl von Ansichten ab",
     "views": "Ansichten",
     "view_limit_info": "Dieser Paste läuft nach {{count}} Ansicht(en) ab",
-    "password_placeholder": "Optional - leer lassen für freien Zugang"
+    "password_placeholder": "Optional - leer lassen für freien Zugang",
+    "shortcut": "Tipp:",
+    "shortcut_tail": "zum schnellen Erstellen"
   },
   "fileshare": {
     "title": "FileShare",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -60,7 +60,9 @@
     "view_limit_desc": "The paste will expire after a set number of views",
     "views": "views",
     "view_limit_info": "This paste will expire after {{count}} view(s)",
-    "password_placeholder": "Optional - leave empty for free access"
+    "password_placeholder": "Optional - leave empty for free access",
+    "shortcut": "Tip:",
+    "shortcut_tail": "to create quickly"
   },
   "fileshare": {
     "title": "FileShare",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -60,7 +60,9 @@
     "view_limit_desc": "El paste expirará después de un número definido de vistas",
     "views": "vistas",
     "view_limit_info": "Este paste expirará después de {{count}} vista(s)",
-    "password_placeholder": "Opcional - déjalo vacío para acceso libre"
+    "password_placeholder": "Opcional - déjalo vacío para acceso libre",
+    "shortcut": "Consejo:",
+    "shortcut_tail": "para crear rápidamente"
   },
   "fileshare": {
     "title": "FileShare",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -60,7 +60,9 @@
     "view_limit_desc": "Le paste expirera après un nombre défini de vues",
     "views": "vues",
     "view_limit_info": "Ce paste expirera après {{count}} vue(s)",
-    "password_placeholder": "Optionnel - laissez vide pour un accès libre"
+    "password_placeholder": "Optionnel - laissez vide pour un accès libre",
+    "shortcut": "Astuce :",
+    "shortcut_tail": "pour créer rapidement"
   },
   "fileshare": {
     "title": "FileShare",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -64,7 +64,9 @@
     "view_limit_desc": "De paste verloopt na een ingesteld aantal weergaves",
     "views": "weergaves",
     "view_limit_info": "Deze paste verloopt na {{count}} weergave(s)",
-    "password_placeholder": "Optioneel - leeg laten voor vrije toegang"
+    "password_placeholder": "Optioneel - leeg laten voor vrije toegang",
+    "shortcut": "Tip:",
+    "shortcut_tail": "om snel aan te maken"
   },
   "fileshare": {
     "title": "FileShare",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -64,7 +64,9 @@
     "view_limit_desc": "Wklejka wygasa po określonej liczbie wyświetleń",
     "views": "wyświetlenia",
     "view_limit_info": "Ta wklejka wygaśnie po {{count}} wyświetleniu/ach",
-    "password_placeholder": "Zostaw puste dla otwartego dostępu"
+    "password_placeholder": "Zostaw puste dla otwartego dostępu",
+    "shortcut": "Wskazówka:",
+    "shortcut_tail": "aby utworzyć szybko"
   },
   "fileshare": {
     "title": "Udostępnianie plików",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
### Overview
This pull request enhances the user experience by introducing global keyboard shortcuts and seamless clipboard integration for switching tabs, pre-filling content, and quickly creating shares.

### Key Changes

* **Tab Navigation Shortcuts**: 
  * Users can now quickly switch between sharing modes using keyboard shortcuts:
    * `Alt + 1` to switch to **LinkShare**
    * `Alt + 2` to switch to **PasteShare**
    * `Alt + 3` to switch to **FileShare**

* **Smart Clipboard Pasting**:
  * **Files**: Pasting files or images anywhere on the page automatically switches the active tab to **FileShare** and pre-loads the pasted files.
  * **Text**: Pasting plain text (when not actively editing an input or text area) automatically switches the active tab to **PasteShare** and populates the editor with the clipboard content.

* **Quick Paste Creation**:
  * Added a `Ctrl + Enter` (or `Cmd + Enter`) keyboard shortcut to quickly submit and create a paste from the PasteShare form.
  * Added a localized tip below the paste creation form to inform users of this shortcut.

* **Localization**:
  * Added translation strings for the new shortcut tip in German, English, Spanish, French, Dutch, and Polish.
<!-- kody-pr-summary:end -->