### PR TITLE
feat: GDPR data export from profile

### DIFF
--- a/src/app/api/user/export/route.ts
+++ b/src/app/api/user/export/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { apiError, internalError, ErrorCode } from "@/lib/api-errors";
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return apiError(request, ErrorCode.UNAUTHORIZED);
+    }
+
+    const userId = session.user.id;
+
+    const [user, shares, apiKeys, accounts] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          createdAt: true,
+          updatedAt: true,
+          defaultTab: true,
+          ssoAutoLink: true,
+        },
+      }),
+      prisma.share.findMany({
+        where: { ownerId: userId },
+        select: {
+          type: true,
+          slug: true,
+          paste: true,
+          pastelanguage: true,
+          urlOriginal: true,
+          createdAt: true,
+          expiresAt: true,
+          isBulk: true,
+          maxViews: true,
+          viewCount: true,
+          files: {
+            select: {
+              originalName: true,
+              relativePath: true,
+              size: true,
+              mimeType: true,
+              createdAt: true,
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.apiKey.findMany({
+        where: { userId },
+        select: {
+          name: true,
+          keyPrefix: true,
+          createdAt: true,
+          lastUsedAt: true,
+          expiresAt: true,
+        },
+      }),
+      prisma.account.findMany({
+        where: { userId },
+        select: {
+          provider: true,
+          type: true,
+        },
+      }),
+    ]);
+
+    if (!user) {
+      return apiError(request, ErrorCode.USER_NOT_FOUND);
+    }
+
+    const exportData = {
+      exportedAt: new Date().toISOString(),
+      profile: user,
+      shares: shares.map((s) => ({
+        ...s,
+        files: s.files.map((f) => ({ ...f, size: f.size.toString() })),
+      })),
+      apiKeys,
+      connectedAccounts: accounts,
+    };
+
+    const filename = `snowshare-export-${new Date().toISOString().slice(0, 10)}.json`;
+
+    return new NextResponse(JSON.stringify(exportData, null, 2), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (error) {
+    console.error("Error generating data export:", error);
+    return internalError(request);
+  }
+}

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Download } from "lucide-react";
 
 type User = {
   id: string;
@@ -27,6 +28,7 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -298,6 +300,70 @@ export default function ProfileInfo({ user, onUpdate }: ProfileInfoProps) {
           )}
         </button>
       </form>
+
+      <div className="border-t border-[var(--border)] mt-6 pt-6">
+        <h3 className="text-lg font-medium text-[var(--foreground)] mb-1 flex items-center gap-2">
+          <Download className="w-5 h-5 text-[var(--secondary)]" />
+          {t("profile.export_title")}
+        </h3>
+        <p className="text-sm text-[var(--foreground-muted)] mb-4">{t("profile.export_desc")}</p>
+        <button
+          type="button"
+          disabled={exporting}
+          onClick={async () => {
+            setExporting(true);
+            try {
+              const res = await fetch("/api/user/export");
+              if (!res.ok) throw new Error();
+              const blob = await res.blob();
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download =
+                res.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ??
+                "snowshare-export.json";
+              a.click();
+              URL.revokeObjectURL(url);
+            } catch {
+              alert(t("profile.export_error"));
+            } finally {
+              setExporting(false);
+            }
+          }}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-[var(--border)] text-[var(--foreground)] hover:bg-[var(--surface-hover)] transition-colors disabled:opacity-50"
+        >
+          {exporting ? (
+            <>
+              <svg
+                className="animate-spin w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+              {t("profile.export_downloading")}
+            </>
+          ) : (
+            <>
+              <Download className="w-4 h-4" />
+              {t("profile.export_button")}
+            </>
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -332,7 +332,12 @@
     "default_tab_desc": "Standardmäßig angezeigter Tab auf der Startseite",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Meine Daten exportieren",
+    "export_desc": "Lade eine Kopie aller deiner persönlichen Daten (Profil, Freigaben, API-Schlüssel, verknüpfte Konten) im JSON-Format herunter.",
+    "export_button": "Meine Daten herunterladen",
+    "export_downloading": "Wird heruntergeladen…",
+    "export_error": "Export fehlgeschlagen. Bitte versuche es erneut."
   },
   "apikeys": {
     "title": "API-Schlüssel",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -336,7 +336,12 @@
     "default_tab_desc": "Tab shown by default on the home page",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Export my data",
+    "export_desc": "Download a copy of all your personal data (profile, shares, API keys, linked accounts) in JSON format.",
+    "export_button": "Download my data",
+    "export_downloading": "Downloading…",
+    "export_error": "Export failed. Please try again."
   },
   "apikeys": {
     "title": "API Keys",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -332,7 +332,12 @@
     "default_tab_desc": "Pestaña mostrada por defecto en la página de inicio",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Exportar mis datos",
+    "export_desc": "Descarga una copia de todos tus datos personales (perfil, compartidos, claves API, cuentas vinculadas) en formato JSON.",
+    "export_button": "Descargar mis datos",
+    "export_downloading": "Descargando…",
+    "export_error": "Error al exportar. Por favor, inténtalo de nuevo."
   },
   "apikeys": {
     "title": "Claves API",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -336,7 +336,12 @@
     "default_tab_desc": "Onglet affiché par défaut sur la page d'accueil",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Exporter mes données",
+    "export_desc": "Téléchargez une copie de toutes vos données personnelles (profil, partages, clés API, comptes liés) au format JSON.",
+    "export_button": "Télécharger mes données",
+    "export_downloading": "Téléchargement…",
+    "export_error": "Erreur lors de l'export. Veuillez réessayer."
   },
   "apikeys": {
     "title": "Clés API",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -340,7 +340,12 @@
     "default_tab_desc": "Tabblad dat standaard wordt weergegeven op de startpagina",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Mijn gegevens exporteren",
+    "export_desc": "Download een kopie van al je persoonlijke gegevens (profiel, delingen, API-sleutels, gekoppelde accounts) in JSON-formaat.",
+    "export_button": "Mijn gegevens downloaden",
+    "export_downloading": "Downloaden…",
+    "export_error": "Export mislukt. Probeer het opnieuw."
   },
   "apikeys": {
     "title": "API-sleutels",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -340,7 +340,12 @@
     "default_tab_desc": "Zakładka wyświetlana domyślnie na stronie głównej",
     "default_tab_linkshare": "LinkShare",
     "default_tab_pasteshare": "PasteShare",
-    "default_tab_fileshare": "FileShare"
+    "default_tab_fileshare": "FileShare",
+    "export_title": "Eksportuj moje dane",
+    "export_desc": "Pobierz kopię wszystkich swoich danych osobowych (profil, udostępnienia, klucze API, połączone konta) w formacie JSON.",
+    "export_button": "Pobierz moje dane",
+    "export_downloading": "Pobieranie…",
+    "export_error": "Eksport nie powiódł się. Spróbuj ponownie."
   },
   "apikeys": {
     "title": "Klucze API",


### PR DESCRIPTION
## Summary

- Add `GET /api/user/export` endpoint that generates a JSON file with all personal data for the authenticated user
- Exported data includes: profile info, all shares (with file metadata), API key metadata (no hashes), and connected OAuth accounts
- Add a download button in the **Profile** tab with a loading state
- Translations added for all 6 locales (fr, en, es, de, nl, pl)

## Test plan

- [ ] Log in and go to `/profile` → Profile tab
- [ ] Click "Download my data" — a `.json` file should download
- [ ] Open the file and verify it contains your profile, shares, API keys, and linked accounts
- [ ] Verify passwords and sensitive hashes are **not** included
- [ ] Test with each language and confirm the button label is translated
- [ ] Test unauthenticated access to `/api/user/export` → should return 401