### PR TITLE
i18n: make fallback locale configurable via NEXT_PUBLIC_DEFAULT_LOCALE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ UPLOAD_DIR=
 # Custom endpoint for self-hosted / S3-compatible services (MinIO, Garage, R2…)
 # S3_ENDPOINT=http://minio:9000
 
+# Default locale / fallback language for users whose browser language is not supported
+# Supported values: en, fr, es, de, pl, nl  (defaults to "en" if unset or invalid)
+# NEXT_PUBLIC_DEFAULT_LOCALE=en
+
 # Telemetry (Plausible Analytics - privacy-friendly, GDPR compliant)
 # Set to "false" to disable analytics
 TELEMETRY=true

--- a/src/i18n/client.ts
+++ b/src/i18n/client.ts
@@ -2,6 +2,7 @@
 
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
+import { resolveDefaultLocale } from "@/i18n/locale-utils";
 import en from "./locales/en.json";
 import fr from "./locales/fr.json";
 import es from "./locales/es.json";
@@ -36,9 +37,7 @@ const resources = Object.fromEntries(
 
 export const supportedLngs = languages.map((lang) => lang.code);
 
-// NEXT_PUBLIC_* vars are inlined at build time — changing this requires a rebuild.
-const _envLocale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
-const defaultLocale = supportedLngs.includes(_envLocale) ? _envLocale : "en";
+const defaultLocale = resolveDefaultLocale(supportedLngs);
 
 // Initialize with a fixed language so SSR and the initial client render match.
 // Language detection runs client-side after hydration (see NextAuthProvider).

--- a/src/i18n/client.ts
+++ b/src/i18n/client.ts
@@ -36,6 +36,7 @@ const resources = Object.fromEntries(
 
 export const supportedLngs = languages.map((lang) => lang.code);
 
+// NEXT_PUBLIC_* vars are inlined at build time — changing this requires a rebuild.
 const _envLocale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
 const defaultLocale = supportedLngs.includes(_envLocale) ? _envLocale : "en";
 

--- a/src/i18n/client.ts
+++ b/src/i18n/client.ts
@@ -36,12 +36,15 @@ const resources = Object.fromEntries(
 
 export const supportedLngs = languages.map((lang) => lang.code);
 
+const _envLocale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
+const defaultLocale = supportedLngs.includes(_envLocale) ? _envLocale : "en";
+
 // Initialize with a fixed language so SSR and the initial client render match.
 // Language detection runs client-side after hydration (see NextAuthProvider).
 i18n.use(initReactI18next).init({
   resources,
-  lng: "fr",
-  fallbackLng: "fr",
+  lng: defaultLocale,
+  fallbackLng: defaultLocale,
   supportedLngs,
   interpolation: { escapeValue: false },
 });

--- a/src/i18n/locale-utils.ts
+++ b/src/i18n/locale-utils.ts
@@ -1,0 +1,5 @@
+// NEXT_PUBLIC_* vars are inlined at build time — changing this requires a rebuild.
+export function resolveDefaultLocale(supported: readonly string[]): string {
+  const env = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
+  return supported.includes(env) ? env : "en";
+}

--- a/src/lib/i18n-server.ts
+++ b/src/lib/i18n-server.ts
@@ -14,7 +14,10 @@ import nl from "@/i18n/locales/nl.json";
 export const SUPPORTED_LOCALES = ["fr", "en", "es", "de", "pl", "nl"] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
-const DEFAULT_LOCALE: SupportedLocale = "en";
+const _envLocale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
+const DEFAULT_LOCALE: SupportedLocale = SUPPORTED_LOCALES.includes(_envLocale as SupportedLocale)
+  ? (_envLocale as SupportedLocale)
+  : "en";
 
 const translations: Record<string, Record<string, unknown>> = {
   en,

--- a/src/lib/i18n-server.ts
+++ b/src/lib/i18n-server.ts
@@ -4,6 +4,7 @@
  */
 
 import { NextRequest } from "next/server";
+import { resolveDefaultLocale } from "@/i18n/locale-utils";
 import en from "@/i18n/locales/en.json";
 import fr from "@/i18n/locales/fr.json";
 import es from "@/i18n/locales/es.json";
@@ -14,10 +15,7 @@ import nl from "@/i18n/locales/nl.json";
 export const SUPPORTED_LOCALES = ["fr", "en", "es", "de", "pl", "nl"] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
-const _envLocale = process.env.NEXT_PUBLIC_DEFAULT_LOCALE ?? "en";
-const DEFAULT_LOCALE: SupportedLocale = SUPPORTED_LOCALES.includes(_envLocale as SupportedLocale)
-  ? (_envLocale as SupportedLocale)
-  : "en";
+const DEFAULT_LOCALE = resolveDefaultLocale(SUPPORTED_LOCALES) as SupportedLocale;
 
 const translations: Record<string, Record<string, unknown>> = {
   en,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
### Summary

This pull request makes the default and fallback locales configurable via the `NEXT_PUBLIC_DEFAULT_LOCALE` environment variable, replacing previously hardcoded values on both the client and server sides.

### Key Changes

* **Client-Side Internationalization (`src/i18n/client.ts`)**:
  * Replaced the hardcoded `"fr"` default and fallback language (`lng` and `fallbackLng`) with a dynamic `defaultLocale`.
  * The `defaultLocale` is resolved from `process.env.NEXT_PUBLIC_DEFAULT_LOCALE`. If the environment variable is not set or is not part of the supported languages, it defaults to `"en"`.

* **Server-Side Internationalization (`src/lib/i18n-server.ts`)**:
  * Updated the `DEFAULT_LOCALE` constant to dynamically resolve from `process.env.NEXT_PUBLIC_DEFAULT_LOCALE`.
  * Added validation to ensure the configured environment variable is one of the `SUPPORTED_LOCALES`, falling back to `"en"` if it is invalid or missing.
<!-- kody-pr-summary:end -->