### PR TITLE
fix: clicktocopy button resubmits the form creating duplicate shares

### DIFF
--- a/src/components/shareComponents/ShareSuccess.tsx
+++ b/src/components/shareComponents/ShareSuccess.tsx
@@ -141,6 +141,7 @@ const ShareSuccess: React.FC<ShareSuccessProps> = ({ url, slug, translationPrefi
           </div>
           <div className="flex-shrink-0 flex items-start gap-2">
             <button
+              type="button"
               onClick={() => copyToClipboard(url)}
               className="p-2 text-[var(--foreground-muted)] hover:text-[var(--foreground)] hover:bg-[var(--border)] rounded-[var(--radius)] transition-colors"
               title={t(`${translationPrefix}.copy_title`, "Copier le lien")}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
### Summary of Changes

This pull request resolves an issue where clicking the copy-to-clipboard button on the share success screen unintentionally resubmitted the share form, resulting in duplicate shares.

### Key Changes

* **`src/components/shareComponents/ShareSuccess.tsx`**: Added the explicit `type="button"` attribute to the copy-to-clipboard button. 

### Functional Impact

By explicitly setting the button type to `"button"`, it prevents the browser's default behavior of treating the button as a form submission trigger (which defaults to `type="submit"` when nested inside a form). Users can now copy the generated share link to their clipboard without triggering an accidental form resubmission.
<!-- kody-pr-summary:end -->