### PR TITLE
fix(fileshare): repair bulk share download (#305)

### DIFF
--- a/src/app/(shares)/f/[slug]/api/route.ts
+++ b/src/app/(shares)/f/[slug]/api/route.ts
@@ -34,7 +34,7 @@ export async function POST(
 
   try {
     if (action === "info") {
-      const result = await getFileShare(slug);
+      const result = await getFileShare(slug, password);
 
       if (result.errorCode && !result.requiresPassword) {
         return apiError(request, result.errorCode);

--- a/src/app/(shares)/f/[slug]/file-preview/route.ts
+++ b/src/app/(shares)/f/[slug]/file-preview/route.ts
@@ -36,7 +36,8 @@ async function validateShareAccess(
 
 async function buildFileResponse(
   shareFile: { filePath: string; originalName: string | null; mimeType: string | null },
-  fileSize: number
+  fileSize: number,
+  forceDownload = false
 ): Promise<NextResponse> {
   let contentType = shareFile.mimeType || "application/octet-stream";
   if (!shareFile.mimeType) {
@@ -46,15 +47,14 @@ async function buildFileResponse(
   const fileStream = await getStorageReadStream(shareFile.filePath);
   const webStream = nodeStreamToWebStream(fileStream);
 
+  const disposition = !forceDownload && isSafeForInline(contentType) ? "inline" : "attachment";
+
   const headers = new Headers();
   headers.set("Content-Length", fileSize.toString());
   headers.set("Content-Type", contentType);
   headers.set("Accept-Ranges", "bytes");
   headers.set("Cache-Control", "no-cache, no-store, must-revalidate");
-  headers.set(
-    "Content-Disposition",
-    `${isSafeForInline(contentType) ? "inline" : "attachment"}; filename="${safeFilename}"`
-  );
+  headers.set("Content-Disposition", `${disposition}; filename="${safeFilename}"`);
 
   return new NextResponse(webStream as ReadableStream<Uint8Array>, { status: 200, headers });
 }
@@ -70,6 +70,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const url = new URL(request.url);
     const relativePath = url.searchParams.get("relativePath");
     const password = url.searchParams.get("password") || undefined;
+    const forceDownload = url.searchParams.get("download") === "1";
 
     if (!relativePath) {
       return apiError(request, ErrorCode.INVALID_REQUEST);
@@ -97,7 +98,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     }
 
     const fileSize = await getStorageFileSize(shareFile.filePath);
-    return buildFileResponse(shareFile, fileSize);
+    return buildFileResponse(shareFile, fileSize, forceDownload);
   } catch (error) {
     console.error("File preview error:", error);
     return internalError(request);

--- a/src/app/(shares)/f/[slug]/page.tsx
+++ b/src/app/(shares)/f/[slug]/page.tsx
@@ -64,11 +64,15 @@ function FilePasswordGate({
 
 function BulkFileList({
   files,
+  slug,
+  password,
   formatFileSize,
   onFileClick,
   t,
 }: {
   files: FileListItem[];
+  slug: string;
+  password: string;
   formatFileSize: (bytes?: number) => string;
   onFileClick: (f: FileListItem) => void;
   t: TFunction;
@@ -93,7 +97,9 @@ function BulkFileList({
             <p className="text-xs text-[var(--foreground-muted)]">{formatFileSize(f.size)}</p>
           </div>
           <a
-            href={`/api/shares/fileShare/download?path=${encodeURIComponent(f.path)}`}
+            href={`/f/${slug}/file-preview?relativePath=${encodeURIComponent(f.path)}&download=1${
+              password ? `&password=${encodeURIComponent(password)}` : ""
+            }`}
             className="shrink-0 text-xs text-[var(--primary)] hover:underline"
             download
             onClick={(e) => e.stopPropagation()}
@@ -421,57 +427,56 @@ export default function FileSharePage() {
               {/* Error message inside download area */}
               {error && <p className="text-sm text-[var(--destructive)]">{error}</p>}
 
-              {fileInfo.isBulk && fileInfo.files && fileInfo.files.length > 0 ? (
+              {/* Bulk: list of files (each downloadable individually) */}
+              {fileInfo.isBulk && fileInfo.files && fileInfo.files.length > 0 && (
                 <BulkFileList
                   files={fileInfo.files}
+                  slug={slug}
+                  password={password}
                   formatFileSize={formatFileSize}
                   onFileClick={handleFileClick}
                   t={t}
                 />
-              ) : (
-                <>
-                  {/* Single file preview button */}
-                  {!fileInfo.isBulk && (
-                    <Button
-                      variant="secondary"
-                      className="w-full"
-                      onClick={handleSingleFilePreview}
-                    >
-                      {t("file_download.preview", "Preview")}
-                    </Button>
-                  )}
-
-                  {/* Download progress bar */}
-                  {downloadedBytes > 0 && totalBytes > 0 && (
-                    <div className="space-y-1">
-                      <div className="h-1.5 rounded-full bg-[var(--border)] overflow-hidden">
-                        <div
-                          className="h-full bg-[var(--primary)] transition-all"
-                          style={{ width: `${Math.round((downloadedBytes / totalBytes) * 100)}%` }}
-                        />
-                      </div>
-                      <p className="text-xs text-[var(--foreground-muted)] text-right">
-                        {formatBytes(downloadedBytes, useGiB)} / {formatBytes(totalBytes, useGiB)}
-                      </p>
-                    </div>
-                  )}
-
-                  <div className="flex gap-2 flex-wrap">
-                    <Button
-                      onClick={() => handleDownload()}
-                      isLoading={loading && !downloadAbortController}
-                      className="flex-1"
-                    >
-                      {t("file_download.download")}
-                    </Button>
-                    {downloadAbortController && (
-                      <Button variant="danger" onClick={handleCancelDownload}>
-                        {t("file_download.cancel_download", "Cancel")}
-                      </Button>
-                    )}
-                  </div>
-                </>
               )}
+
+              {/* Single file preview button */}
+              {!fileInfo.isBulk && (
+                <Button variant="secondary" className="w-full" onClick={handleSingleFilePreview}>
+                  {t("file_download.preview", "Preview")}
+                </Button>
+              )}
+
+              {/* Download progress bar */}
+              {downloadedBytes > 0 && totalBytes > 0 && (
+                <div className="space-y-1">
+                  <div className="h-1.5 rounded-full bg-[var(--border)] overflow-hidden">
+                    <div
+                      className="h-full bg-[var(--primary)] transition-all"
+                      style={{ width: `${Math.round((downloadedBytes / totalBytes) * 100)}%` }}
+                    />
+                  </div>
+                  <p className="text-xs text-[var(--foreground-muted)] text-right">
+                    {formatBytes(downloadedBytes, useGiB)} / {formatBytes(totalBytes, useGiB)}
+                  </p>
+                </div>
+              )}
+
+              <div className="flex gap-2 flex-wrap">
+                <Button
+                  onClick={() => handleDownload()}
+                  isLoading={loading && !downloadAbortController}
+                  className="flex-1"
+                >
+                  {fileInfo.isBulk
+                    ? t("file_download.download_all_zip", "Download all as ZIP")
+                    : t("file_download.download")}
+                </Button>
+                {downloadAbortController && (
+                  <Button variant="danger" onClick={handleCancelDownload}>
+                    {t("file_download.cancel_download", "Cancel")}
+                  </Button>
+                )}
+              </div>
 
               {/* Disclaimer */}
               <p className="text-xs text-[var(--foreground-muted)] text-center">

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -138,6 +138,7 @@
     "password_placeholder": "Passwort eingeben",
     "downloading": "Wird heruntergeladen...",
     "download": "Herunterladen",
+    "download_all_zip": "Alle als ZIP herunterladen",
     "disclaimer": "Mit dem Herunterladen dieser Datei erkennen Sie an, dass sie von einer Drittquelle stammt.",
     "file_count": "{{count}} Dateien",
     "verify_password": "Passwort überprüfen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -142,6 +142,7 @@
     "password_placeholder": "Enter password",
     "downloading": "Downloading...",
     "download": "Download",
+    "download_all_zip": "Download all as ZIP",
     "disclaimer": "By downloading this file, you acknowledge it comes from a third-party source.",
     "file_count": "{{count}} files",
     "verify_password": "Verify Password",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -138,6 +138,7 @@
     "password_placeholder": "Introduce la contraseña",
     "downloading": "Descargando...",
     "download": "Descargar",
+    "download_all_zip": "Descargar todo en ZIP",
     "disclaimer": "Al descargar este archivo, aceptas que proviene de una fuente de terceros.",
     "file_count": "{{count}} archivos",
     "verify_password": "Verificar contraseña",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -142,6 +142,7 @@
     "password_placeholder": "Entrez le mot de passe",
     "downloading": "Téléchargement...",
     "download": "Télécharger",
+    "download_all_zip": "Tout télécharger en ZIP",
     "disclaimer": "En téléchargeant ce fichier, vous acceptez qu'il provient d'une source tierce.",
     "file_count": "{{count}} fichiers",
     "verify_password": "Vérifier le mot de passe",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -146,6 +146,7 @@
     "password_placeholder": "Voer wachtwoord in",
     "downloading": "Downloaden...",
     "download": "Downloaden",
+    "download_all_zip": "Alles downloaden als ZIP",
     "disclaimer": "Door dit bestand te downloaden erken je dat het afkomstig is van een externe bron.",
     "file_count": "{{count}} bestanden",
     "verify_password": "Wachtwoord verifiëren",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -146,6 +146,7 @@
     "password_placeholder": "Wprowadź hasło",
     "downloading": "Pobieranie...",
     "download": "Pobierz",
+    "download_all_zip": "Pobierz wszystko jako ZIP",
     "disclaimer": "Pobierając plik, potwierdzasz, że pochodzi od podmiotu trzeciego.",
     "file_count": "{{count}} plików",
     "verify_password": "Zweryfikuj hasło",


### PR DESCRIPTION
## Summary

Fixes #305 — bulk file shares (multiple loose files) could not be downloaded.

Three distinct bugs were fixed:

1. **Per-file download links pointed to a non-existent route.** Each file in a bulk share linked to `/api/shares/fileShare/download?path=...`. `(fileShare)` is a Next.js route group (the parentheses are stripped from the URL) and there is no `route.ts` there, so the request 404'd. Links now point to the existing `file-preview` endpoint with a new `download=1` flag that forces `Content-Disposition: attachment`.

2. **Password-protected bulk shares never returned their file list.** The `info` action called `getFileShare(slug)` without the password, so after entering a correct password the API still reported `requiresPassword: true` and the file list never appeared. It now passes the password through.

3. **No "Download all as ZIP" button for bulk shares.** The download button, progress bar, and cancel control were only rendered for single-file shares, leaving `handleBulkDownload` unreachable. The download area now renders for bulk shares too, with a "Download all as ZIP" label.

## Changes

- `src/app/(shares)/f/[slug]/api/route.ts` — pass password to `getFileShare` in the `info` action
- `src/app/(shares)/f/[slug]/file-preview/route.ts` — support `download=1` to force attachment disposition
- `src/app/(shares)/f/[slug]/page.tsx` — fix per-file links, add "Download all as ZIP" button + progress/cancel for bulk shares
- `src/i18n/locales/*.json` — add `file_download.download_all_zip` key to all 6 locales

## Testing

- `npm test` for fileshare/download suites — 20 passing
- ESLint clean on changed files
- JSON locale files validated